### PR TITLE
Update the license string

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/molgenis/molgenis-ui-form.git"
   },
-  "license": "GNU LESSER GENERAL PUBLIC LICENSE",
+  "license": "LGPL-3.0+",
   "scripts": {
     "dev": "webpack-dev-server --inline --progress --config build/webpack.dev.conf.js",
     "start": "npm run dev",


### PR DESCRIPTION
Update the license string to valid license string option, this removes the warning.
License is set to same as molgenis/molgenis license.