### PR TITLE
fix 38 clean up console log during unit tests

### DIFF
--- a/src/components/FormComponent.vue
+++ b/src/components/FormComponent.vue
@@ -15,6 +15,7 @@
 <script>
   import VueForm from 'vue-form'
   import FormFieldComponent from './FormFieldComponent'
+  import { isValidSchema } from '../util/SchemaService'
   import { FormHook } from '../flow.types'
 
   export default {
@@ -28,19 +29,7 @@
       schema: {
         type: Object,
         required: true,
-        validator: (schema) => {
-          const fieldIds = new Set()
-
-          const notUnique = schema.fields.some(field => {
-            return fieldIds.size === fieldIds.add(field.id).size
-          })
-
-          if (notUnique) {
-            console.log('Identifiers for fields inside your schema must be unique!')
-            return false
-          }
-          return true
-        }
+        validator: isValidSchema
       },
       data: {
         type: Object,

--- a/src/flow.types.js
+++ b/src/flow.types.js
@@ -13,7 +13,7 @@ export type FieldOption = {
 }
 
 export type FormField = {
-  type: string,
+  type: HtmlFieldType,
   id: string,
   label: string,
   required: (() => boolean),
@@ -21,6 +21,10 @@ export type FormField = {
   visible: (() => boolean),
   options?: (() => Promise<Array<FieldOption>>),
   validate: (() => boolean)
+}
+
+export type Schema = {
+  fields: Array<FormField>
 }
 
 export type RefEntityType = {

--- a/src/util/SchemaService.js
+++ b/src/util/SchemaService.js
@@ -1,0 +1,27 @@
+// @flow
+import type { Schema } from '../flow.types'
+
+function InvalidSchemaException (message: string) {
+  this.message = message
+  this.name = 'InvalidSchemaException'
+}
+
+(InvalidSchemaException.prototype: any).toString = function () { return this.name + ': "' + this.message + '"' }
+
+const isValidSchema = (schema: Schema): boolean => {
+  const fieldIds = new Set()
+
+  const notUnique = schema.fields.some(field => {
+    return fieldIds.size === fieldIds.add(field.id).size
+  })
+
+  if (notUnique) {
+    throw new InvalidSchemaException('Identifiers for fields inside your schema must be unique!')
+  }
+
+  return true
+}
+
+export {
+  isValidSchema
+}

--- a/test/unit/specs/FormComponent.spec.js
+++ b/test/unit/specs/FormComponent.spec.js
@@ -27,42 +27,6 @@ describe('FormComponent unit tests', () => {
     expect(vm.$el.id).to.equal('test-form')
   })
 
-  it('should throw a warning when field IDs are not unique', () => {
-    const Constructor = Vue.extend(FormComponent)
-    const schema = {
-      fields: [
-        {
-          type: 'text',
-          id: 'text-field',
-          label: 'Text field',
-          description: 'This is a cool text field',
-          visible: true,
-          required: true,
-          disabled: false,
-          validators: []
-        },
-        {
-          type: 'text',
-          id: 'text-field',
-          label: 'Text field',
-          description: 'This is a cool text field',
-          visible: true,
-          required: true,
-          disabled: false,
-          validators: []
-        }
-      ]
-    }
-
-    const spy = sinon.spy(console, 'log')
-
-    const propsData = {id: 'test-form', schema}
-    new Constructor({propsData: propsData, mixins: [VueForm]}).$mount()
-
-    expect(spy.args[0][0]).to.equal('Identifiers for fields inside your schema must be unique!')
-    console.log.restore()
-  })
-
   it('renders correctly with real props', () => {
     const Constructor = Vue.extend(FormComponent)
     const schema = {

--- a/test/unit/specs/util/SchemaService.spec.js
+++ b/test/unit/specs/util/SchemaService.spec.js
@@ -1,0 +1,51 @@
+import {isValidSchema} from '@/util/SchemaService'
+
+describe('SchemaService', () => {
+  describe('isValidSchema', () => {
+    it('should return true if the schema is valid', () => {
+      const validSchema = {
+        fields: [{
+          type: 'text',
+          id: 'id1',
+          label: 'label1',
+          required: () => true,
+          disabled: false,
+          visible: () => true,
+          validate: () => true
+        }]
+      }
+
+      expect(isValidSchema(validSchema)).to.equal(true)
+    })
+
+    it('should throw an error if the schema is invalid', () => {
+      const invalidSchema = {
+        fields: [
+          {
+            type: 'text',
+            id: 'id1',
+            label: 'label1',
+            required: () => true,
+            disabled: false,
+            visible: () => true,
+            validate: () => true
+          },
+          {
+            type: 'text',
+            id: 'id1',
+            label: 'otherLabel',
+            required: () => true,
+            disabled: false,
+            visible: () => true,
+            validate: () => true
+          }]
+      }
+
+      const result = () => {
+        isValidSchema(invalidSchema)
+      }
+
+      expect(result).to.throw('Identifiers for fields inside your schema must be unique!')
+    })
+  })
+})


### PR DESCRIPTION
clean up console log during unit tests

The FormComponent now uses a separate service to validate its schema property

- move logic to separate module to avoid mixin business logic with render logic
- add test ( no need for mocks as it is pure js code)
- use exception instead of console log to avoid needing spy during test and having error in logs