### PR TITLE
code cleanup fix lint warning

### DIFF
--- a/test/unit/specs/field-types/MultiSelectFieldComponent.spec.js
+++ b/test/unit/specs/field-types/MultiSelectFieldComponent.spec.js
@@ -197,7 +197,7 @@ describe('MultiSelectFieldComponent unit tests', () => {
 
     const propsData = {
       field: field,
-      state: state,
+      fieldState: fieldState,
       isRequired: true,
       isValid: true,
       eventBus: {


### PR DESCRIPTION
When running yarn lint the linter warns about a missing 'state' variable, this is changed to 'fieldState'. The renaming of state to fieldState was part of a previous PR to have more structured naming.