### PR TITLE
loosen test assertion to work around interaction effect of IE and Chr…

### DIFF
--- a/test/e2e/specs/form-interaction-tests.js
+++ b/test/e2e/specs/form-interaction-tests.js
@@ -28,7 +28,7 @@ module.exports = {
     browser.options.desiredCapabilities.name = 'Change value in field and check if event is fired'
     browser.setValue('#string', 'test string')
     browser.expect.element('#message-span').to.be.visible
-    browser.expect.element('#message-span').text.to.contain('"string":"string valuetest string"')
+    browser.expect.element('#message-span').text.to.contain('test string')
 
     browser.setValue('#integer', 1000)
     browser.expect.element('#message-span').to.be.visible


### PR DESCRIPTION
…ome selenium/nightwatch bugs

'clearValue' is broken in newest version of chrome
and
'setValue' prepends ( instead of appends) in IE :S

By just checking for the added text we work around these issues