### PR TITLE
forgot to rename var, this results in warning during test

### DIFF
--- a/test/unit/specs/FormComponent.spec.js
+++ b/test/unit/specs/FormComponent.spec.js
@@ -41,7 +41,7 @@ describe('FormComponents shallow tests', () => {
 
   const propsData = {
     id: 'test',
-    data: {'string': 'data'},
+    formData: {'string': 'data'},
     schema: {
       fields: [ field ]
     },


### PR DESCRIPTION
forgot to rename var, this results in warning during test, renaming mocks to expected formData' removes this warning