### PR TITLE
Add shim to index.html to shim 'array.find' 

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <script src="node_modules/es6-promise-polyfill/promise.min.js"></script>
+    <script src="node_modules/es6-shim/es6-shim.min.js"></script>
     <link rel="shortcut icon" href="https://avatars1.githubusercontent.com/u/1688158?v=4&s=280" />
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "cross-spawn": "^5.0.1",
     "css-loader": "^0.28.0",
     "es6-promise-polyfill": "^1.2.0",
+    "es6-shim": "^0.35.3",
     "eslint": "^3.19.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-friendly-formatter": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2468,6 +2468,10 @@ es6-set@~0.1.5:
     es6-symbol "3.1.1"
     event-emitter "~0.3.5"
 
+es6-shim@^0.35.3:
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.3.tgz#9bfb7363feffff87a6cdb6cd93e405ec3c4b6f26"
+
 es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"


### PR DESCRIPTION
Add shim to index.html to shim 'array.find' ( and of missing features) during dev and test.

This should fix the remote test running on ie11. During production the containing application ( molgenis should supply shims)