### PR TITLE
Remove 'schema' wrapper object from wrapping the fields array, it is …

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ const form = EntityToFormMapper(response.meta, response.items[0]
 
 data () {
   return {
-    schema: {
-      fields: form.formFields
-    },
+    formFields: form.formFields,
     data: form.formData
   }
 }
@@ -40,7 +38,7 @@ data () {
 <template>
     <form-component
       id="my-form"
-      :schema="schema"
+      :formFields="formFields"
       :formState="formState"
       :formData="formData"
       :onValueChanged="onValueChanged"

--- a/src/FormDemo.vue
+++ b/src/FormDemo.vue
@@ -21,7 +21,7 @@
           <div class="card-body">
             <form-component
               id="example-form"
-              :schema="schema"
+              :formFields="formFields"
               :formState="formState"
               :formData="formData"
               :onValueChanged="onValueChanged"
@@ -72,7 +72,7 @@
     data () {
       return {
         message: null,
-        schema: {fields: []},
+        formFields: [],
         formState: {},
         formData: {},
         options: {
@@ -101,7 +101,7 @@
     },
     created () {
       const form = EntityToFormMapper.generateForm(EntityTypeV2Response.metadata, EntityTypeV2Response.items)
-      this.schema.fields = form.formFields
+      this.formFields = form.formFields
       this.formData = form.formData
     }
   }

--- a/src/components/FormComponent.vue
+++ b/src/components/FormComponent.vue
@@ -7,7 +7,7 @@
       </button>
     </div>
 
-    <template v-for="field in schema.fields">
+    <template v-for="field in formFields">
       <form-field-component
         :eventBus="eventBus"
         :formData="formData"
@@ -34,8 +34,8 @@
         type: String,
         required: true
       },
-      schema: {
-        type: Object,
+      formFields: {
+        type: Array,
         required: true,
         validator: isValidSchema
       },

--- a/src/flow.types.js
+++ b/src/flow.types.js
@@ -25,10 +25,6 @@ export type FormField = {
   validate: ((?Object) => boolean)
 }
 
-export type Schema = {
-  fields: Array<FormField>
-}
-
 export type RefEntityType = {
   href: string,
   hrefCollection: string,

--- a/src/util/SchemaService.js
+++ b/src/util/SchemaService.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Schema } from '../flow.types'
+import type { FormField } from '../flow.types'
 
 function InvalidSchemaException (message: string) {
   this.message = message
@@ -8,15 +8,15 @@ function InvalidSchemaException (message: string) {
 
 (InvalidSchemaException.prototype: any).toString = function () { return this.name + ': "' + this.message + '"' }
 
-const isValidSchema = (schema: Schema): boolean => {
+const isValidSchema = (formFields: Array<FormField>): boolean => {
   const fieldIds = new Set()
 
-  const notUnique = schema.fields.some(field => {
+  const notUnique = formFields.some(field => {
     return fieldIds.size === fieldIds.add(field.id).size
   })
 
   if (notUnique) {
-    throw new InvalidSchemaException('Identifiers for fields inside your schema must be unique!')
+    throw new InvalidSchemaException('Identifiers for fields inside your formFields must be unique!')
   }
 
   return true

--- a/test/unit/specs/FormComponent.spec.js
+++ b/test/unit/specs/FormComponent.spec.js
@@ -9,7 +9,7 @@ describe('FormComponent unit tests', () => {
   it('should have the correct props listed', () => {
     const props = FormComponent.props
     expect(typeof props.id).to.equal('object')
-    expect(typeof props.schema).to.equal('object')
+    expect(typeof props.formFields).to.equal('object')
     expect(typeof props.formData).to.equal('object')
     expect(typeof props.formState).to.equal('object')
     expect(typeof props.options).to.equal('object')
@@ -43,9 +43,7 @@ describe('FormComponents shallow tests', () => {
   const propsData = {
     id: 'test',
     formData: {'string': 'data'},
-    schema: {
-      fields: [field]
-    },
+    formFields: [field],
     formState: formState,
     options: {
       showEyeButton: true
@@ -73,9 +71,7 @@ describe('FormComponents shallow tests', () => {
       wrapper.setProps({
         id: 'test',
         formData: {'string': 'data'},
-        schema: {
-          fields: [field]
-        },
+        formFields: [field],
         formState: formState,
         options: {
           showEyeButton: false

--- a/test/unit/specs/util/SchemaService.spec.js
+++ b/test/unit/specs/util/SchemaService.spec.js
@@ -2,20 +2,49 @@ import {isValidSchema} from '@/util/SchemaService'
 
 describe('SchemaService', () => {
   describe('isValidSchema', () => {
-    const validSchema = {
-      fields: [{
-        type: 'text',
-        id: 'id1',
-        label: 'label1',
-        required: () => true,
-        disabled: false,
-        visible: () => true,
-        validate: () => true
-      }]
-    }
+    const validFormFields = [{
+      type: 'text',
+      id: 'id1',
+      label: 'label1',
+      required: () => true,
+      disabled: false,
+      visible: () => true,
+      validate: () => true
+    }]
 
-    const invalidSchema = {
-      fields: [
+    const invalidFormFields = [{
+      type: 'text',
+      id: 'id1',
+      label: 'label1',
+      required: () => true,
+      disabled: false,
+      visible: () => true,
+      validate: () => true
+    }, {
+      type: 'text',
+      id: 'id1',
+      label: 'otherLabel',
+      required: () => true,
+      disabled: false,
+      visible: () => true,
+      validate: () => true
+    }]
+
+    it('should return true if the schema is valid', () => {
+      expect(isValidSchema(validFormFields)).to.equal(true)
+    })
+
+    it('should test the exception', () => {
+      try {
+        isValidSchema(invalidFormFields)
+      } catch (exception) {
+        const message = exception.toString()
+        expect(message).to.equal('InvalidSchemaException: "Identifiers for fields inside your formFields must be unique!"')
+      }
+    })
+
+    it('should throw an error if the schema is invalid', () => {
+      const invalidSchema = [
         {
           type: 'text',
           id: 'id1',
@@ -34,49 +63,12 @@ describe('SchemaService', () => {
           visible: () => true,
           validate: () => true
         }]
-    }
-
-    it('should return true if the schema is valid', () => {
-      expect(isValidSchema(validSchema)).to.equal(true)
-    })
-
-    it('should test the exception', () => {
-      try {
-        isValidSchema(invalidSchema)
-      } catch (exception) {
-        const message = exception.toString()
-        expect(message).to.equal('InvalidSchemaException: "Identifiers for fields inside your schema must be unique!"')
-      }
-    })
-
-    it('should throw an error if the schema is invalid', () => {
-      const invalidSchema = {
-        fields: [
-          {
-            type: 'text',
-            id: 'id1',
-            label: 'label1',
-            required: () => true,
-            disabled: false,
-            visible: () => true,
-            validate: () => true
-          },
-          {
-            type: 'text',
-            id: 'id1',
-            label: 'otherLabel',
-            required: () => true,
-            disabled: false,
-            visible: () => true,
-            validate: () => true
-          }]
-      }
 
       const result = () => {
         isValidSchema(invalidSchema)
       }
 
-      expect(result).to.throw('Identifiers for fields inside your schema must be unique!')
+      expect(result).to.throw('Identifiers for fields inside your formFields must be unique!')
     })
   })
 })


### PR DESCRIPTION
Remove 'schema' wrapper object from wrapping the fields array, it is not needed.

The formComponent now directly takes a array of fields, named formFields