### PR TITLE
FormComponent formData watches initialFormData property

### DIFF
--- a/src/FormDemo.vue
+++ b/src/FormDemo.vue
@@ -88,16 +88,13 @@
       onSubmit () {
         this.message = 'onSubmit: ' + JSON.stringify(this.formData)
       },
-
       onCancel () {
         this.message = 'onCancel'
       },
-
       onValueChanged (formData) {
         this.message = 'onValueChanged: ' + JSON.stringify(formData)
         this.formData = formData
       },
-
       handleAddOptionRequest (completedFunction, event, data) {
         const newMockOption = {
           id: Math.floor(Math.random() * 1000),
@@ -106,7 +103,6 @@
         }
         completedFunction(newMockOption)
       },
-
       changeData () {
         this.formData['nested-compound-string'] = 'show'
         this.formData['comppound-int'] = '1'

--- a/src/FormDemo.vue
+++ b/src/FormDemo.vue
@@ -13,6 +13,7 @@
         <div class="card">
           <div class="card-header">
             <h5>Example form</h5>
+            <button id="update-data-btn" type="button" @click="changeData">Change form data</button>
           </div>
 
           <div id="alert-message" v-if="message" class="alert alert-info" role="alert">
@@ -87,13 +88,16 @@
       onSubmit () {
         this.message = 'onSubmit: ' + JSON.stringify(this.formData)
       },
+
       onCancel () {
         this.message = 'onCancel'
       },
+
       onValueChanged (formData) {
         this.message = 'onValueChanged: ' + JSON.stringify(formData)
         this.formData = formData
       },
+
       handleAddOptionRequest (completedFunction, event, data) {
         const newMockOption = {
           id: Math.floor(Math.random() * 1000),
@@ -101,6 +105,11 @@
           value: 'Demo value'
         }
         completedFunction(newMockOption)
+      },
+
+      changeData () {
+        this.formData['nested-compound-string'] = 'show'
+        this.formData['comppound-int'] = '1'
       }
     },
     created () {

--- a/src/components/FormComponent.vue
+++ b/src/components/FormComponent.vue
@@ -79,16 +79,13 @@
       FormFieldComponent
     },
     computed: {
-
-      /**
-       * Compute the on hover text for the eye button
-       */
       eyeMessage () {
         return this.showOptionalFields ? 'Hide optional fields' : 'Show all fields'
       },
 
       /**
-       *  Create local copy for data
+       *  Create local copy to break data reactivity with the
+       *  outside world and "enforce" a one way data-flow
        */
       formData () {
         return Object.assign({}, this.initialFormData)

--- a/src/components/FormComponent.vue
+++ b/src/components/FormComponent.vue
@@ -61,12 +61,7 @@
     data () {
       return {
         eventBus: new Vue(),
-        showOptionalFields: true,
-
-        /**
-         *  Create local copy for data
-         */
-        formData: Object.assign({}, this.initialFormData)
+        showOptionalFields: true
       }
     },
     methods: {
@@ -84,8 +79,19 @@
       FormFieldComponent
     },
     computed: {
+
+      /**
+       * Compute the on hover text for the eye button
+       */
       eyeMessage () {
         return this.showOptionalFields ? 'Hide optional fields' : 'Show all fields'
+      },
+
+      /**
+       *  Create local copy for data
+       */
+      formData () {
+        return Object.assign({}, this.initialFormData)
       }
     },
     created: function () {

--- a/test/e2e/specs/form-interaction-tests.js
+++ b/test/e2e/specs/form-interaction-tests.js
@@ -116,5 +116,16 @@ module.exports = {
     browser.click('#compound-int') // trigger validation via onBlur()
     browser.expect.element('#compound-string').to.not.have.attribute('class').which.contains('is-invalid')
     browser.end()
+  },
+
+  'Check if expressions work when changing data outside of the form': function (browser) {
+    browser.options.desiredCapabilities.name = 'Check if expressions work when changing data outside of the form'
+    browser.expect.element('#compound-string-fs').to.not.be.visible
+
+    browser.click('#update-data-btn')
+    browser.expect.element('#compound-string-fs').to.be.visible
+    browser.expect.element('#compound-string').to.not.have.attribute('required')
+
+    browser.end()
   }
 }

--- a/test/unit/specs/FormComponent.spec.js
+++ b/test/unit/specs/FormComponent.spec.js
@@ -70,7 +70,7 @@ describe('FormComponents shallow tests', () => {
     it('should not show the eye button', () => {
       wrapper.setProps({
         id: 'test',
-        formData: {'string': 'data'},
+        initialFormData: {'string': 'data'},
         formFields: [field],
         formState: formState,
         options: {
@@ -86,6 +86,28 @@ describe('FormComponents shallow tests', () => {
     it('should emit add "addOptionRequest" event passing through the event params', () => {
       wrapper.vm.handleAddOptionEvent('a', 'b', 'c')
       expect(wrapper.emitted().addOptionRequest[0]).to.deep.equal(['a', 'b', 'c'])
+    })
+  })
+
+  describe('handleValueChange', () => {
+    it('should emit a valueChange event when data changes', () => {
+      wrapper.vm.handleValueChange({'string': 'test event'})
+      expect(wrapper.emitted().valueChange[0]).to.deep.equal([{'string': 'test event'}])
+    })
+  })
+
+  describe('Update initialFormData property updates local formData value', () => {
+    it('should update the computed formData object when the initialFormData prop is updated', () => {
+      wrapper.setProps({
+        id: 'test',
+        initialFormData: {'string': 'new data value'},
+        formFields: [field],
+        options: {
+          showEyeButton: false
+        }
+      })
+
+      expect(wrapper.vm.formData).to.deep.equal({'string': 'new data value'})
     })
   })
 })


### PR DESCRIPTION
Change local formData from being a one time init data value to a computed value.
Updating the initialFormData property will now trigger an update to the local formData.

Although values on screen are not updated due to components having their own local copies, visible, nillable, and validation expressions are reevaluated by the data change.