### PR TITLE
Feature/handle inline options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molgenis/molgenis-ui-form",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Library for generating HTML web forms",
   "author": "Mark-de-Haan <markdehaan90@gmail.com>",
   "main": "dist/static/molgenis-ui-form.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molgenis/molgenis-ui-form",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Library for generating HTML web forms",
   "author": "Mark-de-Haan <markdehaan90@gmail.com>",
   "main": "dist/static/molgenis-ui-form.js",

--- a/src/formDemoMockResponse.js
+++ b/src/formDemoMockResponse.js
@@ -290,7 +290,29 @@ const metadata = {
       'unique': false,
       'visible': true,
       'lookupAttribute': false,
-      'isAggregatable': false
+      'isAggregatable': false,
+      'categoricalOptions': [
+        {
+          'id': 'ref1',
+          'label': 'label1'
+        },
+        {
+          'id': 'ref2',
+          'label': 'label2'
+        },
+        {
+          'id': 'ref3',
+          'label': 'label3'
+        },
+        {
+          'id': 'ref4',
+          'label': 'label4'
+        },
+        {
+          'id': 'ref5',
+          'label': 'label5'
+        }
+      ]
     },
     {
       'href': '/api/v1/it_emx_datatypes_TypeTest/meta/categorical_mref',
@@ -315,7 +337,29 @@ const metadata = {
       'unique': false,
       'visible': true,
       'lookupAttribute': false,
-      'isAggregatable': false
+      'isAggregatable': false,
+      'categoricalOptions': [
+        {
+          'id': 'ref1',
+          'label': 'label1'
+        },
+        {
+          'id': 'ref2',
+          'label': 'label2'
+        },
+        {
+          'id': 'ref3',
+          'label': 'label3'
+        },
+        {
+          'id': 'ref4',
+          'label': 'label4'
+        },
+        {
+          'id': 'ref5',
+          'label': 'label5'
+        }
+      ]
     },
     {
       'href': '/api/v1/it_emx_datatypes_TypeTest/meta/xref',

--- a/src/util/EntityToFormMapper.js
+++ b/src/util/EntityToFormMapper.js
@@ -90,17 +90,27 @@ const fetchFieldOptions = (refEntity: RefEntityType, search: ?string | ?Array<st
  * @returns {Function|null} Function which returns a Promise representing an Array of FieldOptions
  */
 const getFieldOptions = (attribute): ?(() => Promise<Array<FieldOption>>) => {
+  const fetchOptionsFunction = (search: ?string | Array<string>): Promise<Array<FieldOption>> => {
+    return fetchFieldOptions(attribute.refEntity, search).then(response => {
+      return response
+    })
+  }
+
   switch (attribute.fieldType) {
     case 'CATEGORICAL':
     case 'CATEGORICAL_MREF':
+      if (attribute.categoricalOptions) {
+        return () => Promise.resolve(attribute.categoricalOptions.map(option => {
+          option.value = option.id
+          return option
+        }))
+      } else {
+        return fetchOptionsFunction
+      }
     case 'ONE_TO_MANY':
     case 'XREF':
     case 'MREF':
-      return (search: ?string | Array<string>): Promise<Array<FieldOption>> => {
-        return fetchFieldOptions(attribute.refEntity, search).then(response => {
-          return response
-        })
-      }
+      return fetchOptionsFunction
     case 'ENUM':
       const enumOptions = attribute.enumOptions.map(option => {
         return {

--- a/test/unit/specs/util/EntityToFormMapper.spec.js
+++ b/test/unit/specs/util/EntityToFormMapper.spec.js
@@ -562,35 +562,56 @@ describe('Entity to state mapper', () => {
       }
     }
 
-    const form = EntityToFormMapper.generateForm(schemas.categoricalSchema, data)
-    const field = form.formFields[0]
+    describe('when categorical options are not part of the response', () => {
+      const form = EntityToFormMapper.generateForm(schemas.categoricalSchema, data)
+      const field = form.formFields[0]
 
-    it('should map a [CATEGORICAL] attribute to a form field object', done => {
-      expect(field.type).to.equal('radio')
-      expect(field.id).to.equal('categorical')
-      expect(field.label).to.equal('Categorical Field')
-      expect(field.description).to.equal('Categorical description')
-      expect(field.disabled).to.equal(false)
-      expect(field.readOnly).to.equal(false)
-      expect(field.visible()).to.equal(true)
-      expect(typeof field.options).to.equal('function')
+      it('should map a [CATEGORICAL] attribute to a form field object', done => {
+        expect(field.type).to.equal('radio')
+        expect(field.id).to.equal('categorical')
+        expect(field.label).to.equal('Categorical Field')
+        expect(field.description).to.equal('Categorical description')
+        expect(field.disabled).to.equal(false)
+        expect(field.readOnly).to.equal(false)
+        expect(field.visible()).to.equal(true)
+        expect(typeof field.options).to.equal('function')
 
-      field.options().then(response => {
-        expect(response).to.deep.equal([
-          {id: 'ref1', value: 'ref1', label: 'ref1'},
-          {id: 'ref2', value: 'ref2', label: 'ref2'},
-          {id: 'ref3', value: 'ref3', label: 'ref3'}
-        ])
-        done()
+        field.options().then(response => {
+          expect(response).to.deep.equal([
+            {id: 'ref1', value: 'ref1', label: 'ref1'},
+            {id: 'ref2', value: 'ref2', label: 'ref2'},
+            {id: 'ref3', value: 'ref3', label: 'ref3'}
+          ])
+          done()
+        })
+      })
+
+      it('should map a [CATEGORICAL] entity to a form data object', () => {
+        const expectedData = {
+          'categorical': 'ref1'
+        }
+
+        expect(form.formData).to.deep.equal(expectedData)
       })
     })
 
-    it('should map a [CATEGORICAL] entity to a form data object', () => {
-      const expectedData = {
-        'categorical': 'ref1'
-      }
+    describe('when categorical options are included in the response', () => {
+      const form = EntityToFormMapper.generateForm(schemas.categoricalSchemaIncludingOptions, data)
+      const field = form.formFields[0]
 
-      expect(form.formData).to.deep.equal(expectedData)
+      it('should map a [CATEGORICAL] attribute to a form field object', done => {
+        expect(field.type).to.equal('radio')
+        expect(field.id).to.equal('categorical')
+        expect(typeof field.options).to.equal('function')
+
+        field.options().then(response => {
+          expect(response).to.deep.equal([
+            {id: 'ref1', value: 'ref1', label: 'label1'},
+            {id: 'ref2', value: 'ref2', label: 'label2'}
+          ])
+          done()
+        })
+      })
     })
   })
 

--- a/test/unit/specs/util/test-schemas.js
+++ b/test/unit/specs/util/test-schemas.js
@@ -495,6 +495,44 @@ export const categoricalSchema = {
   ]
 }
 
+export const categoricalSchemaIncludingOptions = {
+  'attributes': [
+    {
+      'href': '/api/v2/it_emx_datatypes_TypeTest/meta/categorical',
+      'fieldType': 'CATEGORICAL',
+      'name': 'categorical',
+      'label': 'Categorical Field',
+      'attributes': [],
+      'auto': false,
+      'nillable': true,
+      'readOnly': false,
+      'labelAttribute': true,
+      'unique': true,
+      'visible': true,
+      'lookupAttribute': true,
+      'isAggregatable': false,
+      'description': 'Categorical description',
+      'refEntity': {
+        href: '/api/v1/it_emx_datatypes_TypeTestRef/meta',
+        hrefCollection: '/api/v1/it_emx_datatypes_TypeTestRef',
+        idAttribute: 'value',
+        languageCode: 'en',
+        writable: true
+      },
+      'categoricalOptions': [
+        {
+          'id': 'ref1',
+          'label': 'label1'
+        },
+        {
+          'id': 'ref2',
+          'label': 'label2'
+        }
+      ]
+    }
+  ]
+}
+
 export const categoricalMrefSchema = {
   'attributes': [
     {


### PR DESCRIPTION
Inline options during entity to form mapping + test 

If options a supplied they are inlined using a function returning a promise, this ensures the interface is the same as it was before the inlining was available  