### PR TITLE
Configure waits before starting actual e2e test to allow js code to run

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "karma-mocha": "^1.3.0",
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-promise": "^0.1.0",
+    "karma-safari-launcher": "^1.0.0",
     "karma-sinon-chai": "^1.3.1",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-spec-reporter": "0.0.31",

--- a/test/e2e/nightwatch.conf.js
+++ b/test/e2e/nightwatch.conf.js
@@ -2,6 +2,8 @@ require('babel-register')
 var config = require('../../config')
 var packageJson = require('../../package.json');
 
+var defaultPauzeBeforeTestStart = 3000
+
 // http://nightwatchjs.org/gettingstarted#settings-file
 module.exports = {
   src_folders: ['test/e2e/specs'],
@@ -25,7 +27,9 @@ module.exports = {
       selenium_host: 'localhost',
       silent: true,
       globals: {
-        devServerURL: 'http://localhost:' + (process.env.PORT || config.dev.port)
+        devServerURL: 'http://localhost:' + (process.env.PORT || config.dev.port),
+        waitForConditionTimeout: 10000,
+        waitBeforeTestStart: 1000
       }
     },
 
@@ -43,7 +47,8 @@ module.exports = {
         browserName: 'chrome'
       },
       globals: {
-        waitForConditionTimeout: 10000
+        waitForConditionTimeout: 10000,
+        waitBeforeTestStart: defaultPauzeBeforeTestStart
       }
     },
 
@@ -61,7 +66,8 @@ module.exports = {
         browserName: 'firefox'
       },
       globals: {
-        waitForConditionTimeout: 10000
+        waitForConditionTimeout: 10000,
+        waitBeforeTestStart: defaultPauzeBeforeTestStart
       }
     },
 
@@ -81,7 +87,8 @@ module.exports = {
         version: '11.103',
       },
       globals: {
-        waitForConditionTimeout: 10000
+        waitForConditionTimeout: 10000,
+        waitBeforeTestStart: defaultPauzeBeforeTestStart
       }
     },
 
@@ -99,7 +106,8 @@ module.exports = {
         browserName: 'safari'
       },
       globals: {
-        waitForConditionTimeout: 10000
+        waitForConditionTimeout: 10000,
+        waitBeforeTestStart: 5000
       }
     },
 

--- a/test/e2e/specs/field-render-tests.js
+++ b/test/e2e/specs/field-render-tests.js
@@ -5,6 +5,7 @@ module.exports = {
   before: function (browser) {
     // Wait for form to be loaded
     browser.url(browser.globals.devServerURL)
+    browser.pause(browser.globals.waitBeforeTestStart)
   },
 
   after: function (browser) {

--- a/test/e2e/specs/form-interaction-tests.js
+++ b/test/e2e/specs/form-interaction-tests.js
@@ -5,6 +5,7 @@ module.exports = {
   beforeEach: function (browser) {
     // Wait for form to be loaded
     browser.url(browser.globals.devServerURL)
+    browser.pause(browser.globals.waitBeforeTestStart)
   },
 
   'Click on submit and check if event is fired': function (browser) {
@@ -56,11 +57,11 @@ module.exports = {
 
   'Toggle show optional fields': function (browser) {
     browser.options.desiredCapabilities.name = 'Toggle show optional fields'
-    browser.click('button.toggle-btn')
+    browser.click('.hide-option-fields-btn-container button.toggle-btn')
     browser.expect.element('#string').to.be.not.visible
     browser.expect.element('i.show-fields-icon').to.be.visible
     browser.expect.element('i.show-fields-icon').to.have.attribute('class').which.contains('fa-eye')
-    browser.click('button.toggle-btn')
+    browser.click('.hide-option-fields-btn-container button.toggle-btn')
     browser.expect.element('#string').to.be.visible
     browser.expect.element('i.show-fields-icon').to.have.attribute('class').which.contains('fa-eye-slash')
     browser.end()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4307,6 +4307,10 @@ karma-promise@^0.1.0:
   dependencies:
     es6-promise "^4.0.5"
 
+karma-safari-launcher@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/karma-safari-launcher/-/karma-safari-launcher-1.0.0.tgz#96982a2cc47d066aae71c553babb28319115a2ce"
+
 karma-sinon-chai@^1.3.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/karma-sinon-chai/-/karma-sinon-chai-1.3.3.tgz#a597e5b4a1369fe7b3d7d76c09ed2061a38e747f"


### PR DESCRIPTION
Configure waits before starting actual e2e test to allow js code to run
+
Increase selection specificity on 'click the eye button' selector