### PR TITLE
Add range validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,23 @@ const data = {
 }
 ```
 
+### Range
+A number fields valid input range can be restricted by supplying a range object
+The range object can have a `min` property, a `max` property or both.
+for example 
+
+```js
+{
+  id: 'example-number-with-range',
+  type: 'number',
+  range: {
+    min: 0,
+    max: 13
+  }
+}
+```
+
+
 ### Required, visible, and validate
 As you might have noticed in the above examples, required, visible, and validate are functions returning a boolean.
 The reason for this is that you might want to validate a field based on the input of another field.
@@ -293,6 +310,18 @@ Vue.use(i18n, {
 ```
 
 If no i18n is set on the supplied Vue instance the default (English) messages are used.
+
+#####message keys and defaults
+| Key     | Default message   | Additional Info   |
+| -------: |:-------:| -------|
+| form_required_field| 'This field is required'|
+| form_validation_failed| 'Validation failed'|
+| form_not_a_valid_number| 'Not a valid number'|
+| form_not_a_valid_url| 'Not a valid URL'|
+| form_not_a_valid_email| 'Not a valid email'|
+| form_not_within_range| 'Value is outside of range'|  min, max is added as: ' ($min - $max)' 
+| form_below_min_value| 'Value is below allowed value'| min value is added as: ' $min'
+| form_above_max_value| 'Value is above the allowed value| max value is added as: ' $max'
 
 ### Entity mapper options
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ If no i18n is set on the supplied Vue instance the default (English) messages ar
 | form_not_a_valid_email| 'Not a valid email'|
 | form_not_within_range| 'Value is outside of range'|  min, max is added as: ' ($min - $max)' 
 | form_below_min_value| 'Value is below allowed value'| min value is added as: ' $min'
-| form_above_max_value| 'Value is above the allowed value| max value is added as: ' $max'
+| form_above_max_value| 'Value is above allowed value| max value is added as: ' $max'
 
 ### Entity mapper options
 

--- a/config/index.js
+++ b/config/index.js
@@ -63,6 +63,9 @@ module.exports = {
           'form_not_a_valid_number': 'Not a valid number',
           'form_not_a_valid_url': 'Not a valid URL',
           'form_not_a_valid_email': 'Not a valid email',
+          'form_not_within_range': 'Value is outside of range',
+          'form_below_min_value': 'Value is below allowed value',
+          'form_above_max_value': 'Value is above the allowed value',
           'form_bool_true': 'True',
           'form_bool_false': 'False',
           'form_bool_missing': 'N/A'

--- a/config/index.js
+++ b/config/index.js
@@ -65,7 +65,7 @@ module.exports = {
           'form_not_a_valid_email': 'Not a valid email',
           'form_not_within_range': 'Value is outside of range',
           'form_below_min_value': 'Value is below allowed value',
-          'form_above_max_value': 'Value is above the allowed value',
+          'form_above_max_value': 'Value is above allowed value',
           'form_bool_true': 'True',
           'form_bool_false': 'False',
           'form_bool_missing': 'N/A'

--- a/src/components/FormFieldMessages.vue
+++ b/src/components/FormFieldMessages.vue
@@ -2,22 +2,29 @@
   <field-messages :name="fieldId" :state="fieldState" show="$touched || $submitted" class="form-control-feedback">
     <div class="invalid-message" slot="required">{{ requiredFieldMsg }}</div>
     <div class="invalid-message" slot="validate">{{ validationFailedMsg }}</div>
-    <div v-if="type === 'number'" class="invalid-message" slot="number">{{ notAValidNumberMsg }}</div>
-    <div v-if="type === 'url'" class="invalid-message" slot="url">{{ notAValidUrlMsg }}</div>
-    <div v-if="type === 'email'" class="invalid-message" slot="email">{{ notAValidEmailMsg }}</div>
+    <div class="invalid-message" slot="number">{{ notAValidNumberMsg }}</div>
+    <div class="invalid-message" slot="url">{{ notAValidUrlMsg }}</div>
+    <div class="invalid-message" slot="email">{{ notAValidEmailMsg }}</div>
+    <div v-if="range" class="invalid-message" slot="range">
+      <span v-if="range.hasOwnProperty('min') && range.hasOwnProperty('max')">{{ notWithInRangeMsg }} ({{ range.min }} - {{ range.max }})</span>
+      <span v-else-if="range.hasOwnProperty('min') && !range.hasOwnProperty('max')">{{ belowMinValueMsg }} {{ range.min }} </span>
+      <span v-else>{{ aboveMaxValueMsg }} {{ range.max }} </span>
+    </div>
   </field-messages>
 </template>
 
 <script>
   import VueForm from 'vue-form'
-  import { HtmlFieldType } from '../flow.types'
 
   const defaultMessages = {
     form_required_field: 'This field is required',
     form_validation_failed: 'Validation failed',
     form_not_a_valid_number: 'Not a valid number',
     form_not_a_valid_url: 'Not a valid URL',
-    form_not_a_valid_email: 'Not a valid email'
+    form_not_a_valid_email: 'Not a valid email',
+    form_not_within_range: 'Value is outside of range',
+    form_below_min_value: 'Value is below allowed value',
+    form_above_max_value: 'Value is above the allowed value'
   }
 
   export default {
@@ -28,12 +35,12 @@
         type: [String, Number],
         required: true
       },
-      type: {
-        type: HtmlFieldType,
-        required: true
-      },
       fieldState: {
         type: Object
+      },
+      range: {
+        type: Object,
+        required: false
       }
     },
     data () {
@@ -57,6 +64,10 @@
       this.notAValidNumberMsg = this.getLocalizedMessage('form_not_a_valid_number')
       this.notAValidUrlMsg = this.getLocalizedMessage('form_not_a_valid_url')
       this.notAValidEmailMsg = this.getLocalizedMessage('form_not_a_valid_email')
+
+      this.notWithInRangeMsg = this.getLocalizedMessage('form_not_within_range')
+      this.belowMinValueMsg = this.getLocalizedMessage('form_below_min_value')
+      this.aboveMaxValueMsg = this.getLocalizedMessage('form_above_max_value')
     }
   }
 </script>

--- a/src/components/FormFieldMessages.vue
+++ b/src/components/FormFieldMessages.vue
@@ -24,7 +24,7 @@
     form_not_a_valid_email: 'Not a valid email',
     form_not_within_range: 'Value is outside of range',
     form_below_min_value: 'Value is below allowed value',
-    form_above_max_value: 'Value is above the allowed value'
+    form_above_max_value: 'Value is above allowed value'
   }
 
   export default {

--- a/src/components/field-types/CheckboxFieldComponent.vue
+++ b/src/components/field-types/CheckboxFieldComponent.vue
@@ -25,7 +25,7 @@
         {{ field.description }}
       </small>
 
-      <form-field-messages :field-id="field.id" :type="field.type" :field-state="fieldState">
+      <form-field-messages :field-id="field.id" :field-state="fieldState">
       </form-field-messages>
 
     </div>

--- a/src/components/field-types/CodeEditorFieldComponent.vue
+++ b/src/components/field-types/CodeEditorFieldComponent.vue
@@ -14,7 +14,7 @@
         {{ field.description }}
       </small>
 
-      <form-field-messages :field-id="field.id" :type="field.type" :field-state="fieldState">
+      <form-field-messages :field-id="field.id" :field-state="fieldState">
       </form-field-messages>
     </div>
   </validate>

--- a/src/components/field-types/DateFieldComponent.vue
+++ b/src/components/field-types/DateFieldComponent.vue
@@ -36,7 +36,7 @@
         {{ field.description }}
       </small>
 
-      <form-field-messages :field-id="field.id" :type="field.type" :field-state="fieldState">
+      <form-field-messages :field-id="field.id" :field-state="fieldState">
       </form-field-messages>
 
     </div>

--- a/src/components/field-types/FileFieldComponent.vue
+++ b/src/components/field-types/FileFieldComponent.vue
@@ -22,7 +22,7 @@
         {{ field.description }}
       </small>
 
-      <form-field-messages :field-id="field.id" :type="field.type" :field-state="fieldState">
+      <form-field-messages :field-id="field.id" :field-state="fieldState">
       </form-field-messages>
 
     </div>

--- a/src/components/field-types/MultiSelectFieldComponent.vue
+++ b/src/components/field-types/MultiSelectFieldComponent.vue
@@ -33,7 +33,7 @@
         {{ field.description }}
       </small>
 
-      <form-field-messages :field-id="field.id" :type="field.type" :field-state="fieldState">
+      <form-field-messages :field-id="field.id" :field-state="fieldState">
       </form-field-messages>
 
     </div>

--- a/src/components/field-types/RadioFieldComponent.vue
+++ b/src/components/field-types/RadioFieldComponent.vue
@@ -23,7 +23,7 @@
         {{ field.description }}
       </small>
 
-      <form-field-messages :field-id="field.id" :type="field.type" :field-state="fieldState">
+      <form-field-messages :field-id="field.id" :field-state="fieldState">
       </form-field-messages>
 
     </div>

--- a/src/components/field-types/SingleSelectFieldComponent.vue
+++ b/src/components/field-types/SingleSelectFieldComponent.vue
@@ -31,7 +31,7 @@
         {{ field.description }}
       </small>
 
-      <form-field-messages :field-id="field.id" :type="field.type" :field-state="fieldState">
+      <form-field-messages :field-id="field.id" :field-state="fieldState">
       </form-field-messages>
 
     </div>

--- a/src/components/field-types/TextAreaFieldComponent.vue
+++ b/src/components/field-types/TextAreaFieldComponent.vue
@@ -18,7 +18,7 @@
         {{ field.description }}
       </small>
 
-      <form-field-messages :field-id="field.id" :type="field.type" :field-state="fieldState">
+      <form-field-messages :field-id="field.id" :field-state="fieldState">
       </form-field-messages>
     </div>
   </validate>

--- a/src/components/field-types/TypedFieldComponent.vue
+++ b/src/components/field-types/TypedFieldComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <validate :state="fieldState" :custom="{'validate': isValid}">
+  <validate :state="fieldState" :custom="customValidation">
     <div class="form-group">
       <label :for="field.id">{{ field.label }}</label>
 
@@ -18,7 +18,7 @@
         {{ field.description }}
       </small>
 
-      <form-field-messages :field-id="field.id" :type="field.type" :field-state="fieldState">
+      <form-field-messages :field-id="field.id" :type="field.type" :range="field.range" :field-state="fieldState">
       </form-field-messages>
     </div>
   </validate>
@@ -71,6 +71,27 @@
         // Emit value changes to trigger the onValueChange
         // Do not use input event for this to prevent unwanted behavior
         this.$emit('dataChange')
+      }
+    },
+    computed: {
+      customValidation () {
+        let customValidation = {'validate': this.isValid}
+        if (this.field.type === 'number' && this.field.range) {
+          customValidation.range = this.isWithinRange
+        }
+        return customValidation
+      }
+    },
+    methods: {
+      isWithinRange () {
+        if (this.field.range.hasOwnProperty('min') && this.localValue < this.field.range.min) {
+          return false
+        }
+        if (this.field.range.hasOwnProperty('max') && this.localValue > this.field.range.max) {
+          return false
+        }
+
+        return true
       }
     }
   }

--- a/src/formDemoMockResponse.js
+++ b/src/formDemoMockResponse.js
@@ -67,7 +67,11 @@ const metadata = {
       'visible': true,
       'lookupAttribute': true,
       'isAggregatable': false,
-      'description': 'Integer description'
+      'description': 'Integer description',
+      'range': {
+        'min': 1,
+        'max': 45
+      }
     },
     {
       'href': '/api/v2/it_emx_datatypes_TypeTest/meta/long',

--- a/src/util/EntityToFormMapper.js
+++ b/src/util/EntityToFormMapper.js
@@ -256,9 +256,21 @@ const generateFormSchemaField = (attribute, mapperOptions?: MapperOptions): Form
     validate: isValid(attribute)
   }
 
-  if (fieldProperties.type === 'field-group') {
+  if (attribute.fieldType === 'COMPOUND') {
     const children = attribute.attributes.map(attribute => generateFormSchemaField(attribute, mapperOptions))
     fieldProperties = {...fieldProperties, children}
+  }
+
+  if ((attribute.fieldType === 'INT' || attribute.fieldType === 'LONG') && attribute.range) {
+    let range = {}
+    if (attribute.range.hasOwnProperty('min')) {
+      range.min = attribute.range.min
+    }
+    if (attribute.range.hasOwnProperty('max')) {
+      range.max = attribute.range.max
+    }
+
+    fieldProperties = {...fieldProperties, range}
   }
 
   return options ? {...fieldProperties, options} : fieldProperties

--- a/test/unit/specs/field-types/CheckboxFieldComponent.spec.js
+++ b/test/unit/specs/field-types/CheckboxFieldComponent.spec.js
@@ -1,40 +1,33 @@
 import CheckboxFieldComponent from '@/components/field-types/CheckboxFieldComponent'
-import { mount } from 'vue-test-utils'
+import { shallow } from 'vue-test-utils'
 
 describe('CheckboxFieldComponent unit tests', () => {
+  const options = [
+    {
+      id: '1',
+      label: 'Option 1',
+      value: '1'
+    },
+    {
+      id: '2',
+      label: 'Option 2',
+      value: '2'
+    }
+  ]
   const field = {
     id: 'checkbox-field',
     label: 'Checkbox Field',
     description: 'This is a checkbox field',
     type: 'checkbox',
     disabled: false,
-    options: () => {
-      return new Promise((resolve) => {
-        resolve([
-          {
-            id: '1',
-            label: 'Option 1',
-            value: '1'
-          },
-          {
-            id: '2',
-            label: 'Option 2',
-            value: '2'
-          }
-        ])
-      })
-    }
-  }
-
-  const mockParentFunction = () => {
-    return null
+    options: () => Promise.resolve(options)
   }
 
   const fieldState = {
     $touched: false,
     $submitted: false,
     $invalid: false,
-    _addControl: mockParentFunction
+    _addControl: () => null
   }
 
   const propsData = {
@@ -44,9 +37,17 @@ describe('CheckboxFieldComponent unit tests', () => {
     isValid: true
   }
 
-  const wrapper = mount(CheckboxFieldComponent, {
-    propsData: propsData,
-    stubs: {'fieldMessages': '<div>This field is required</div>'}
+  let wrapper
+
+  beforeEach(function (done) {
+    wrapper = shallow(CheckboxFieldComponent, {
+      attachToDocument: true,
+      propsData: propsData,
+      stubs: ['fieldMessages']
+    })
+    wrapper.vm.$nextTick().then(function () {
+      done()
+    })
   })
 
   it('should set empty array as localValue when value is undefined', () => {

--- a/test/unit/specs/field-types/TypedFieldComponent.spec.js
+++ b/test/unit/specs/field-types/TypedFieldComponent.spec.js
@@ -120,7 +120,11 @@ describe('TypedFieldComponent unit tests', () => {
       label: 'Typed Field',
       description: 'This is a field that supports many types',
       type: 'number',
-      disabled: false
+      disabled: false,
+      range: {
+        min: 1,
+        max: 9
+      }
     }
 
     const fieldState = {
@@ -148,6 +152,57 @@ describe('TypedFieldComponent unit tests', () => {
     it('should render an input of type number', () => {
       const input = wrapper.find('input')
       expect(input.element.type).to.equal('number')
+    })
+  })
+
+  describe('isWithinRange', () => {
+    let propsData = {
+      field: {
+        id: 'typed-field',
+        type: 'number'
+      },
+      fieldState: {
+        $touched: false,
+        $submitted: false,
+        $invalid: false,
+        _addControl: mockParentFunction
+      }
+    }
+    describe('should return true if range is (1, 9) and value is 5', () => {
+      propsData.field.range = {
+        min: 1,
+        max: 9
+      }
+      propsData.value = 5
+      const wrapper = mount(TypedFieldComponent, {propsData: propsData, stubs: ['fieldMessages']})
+      it('if the value is between min and max', () => {
+        const result = wrapper.vm.isWithinRange()
+        expect(result).to.equal(true)
+      })
+    })
+    describe('should return false if range is (1, 9) and value is 11', () => {
+      propsData.field.range = {
+        min: 1,
+        max: 9
+      }
+      propsData.value = 11
+      const wrapper = mount(TypedFieldComponent, {propsData: propsData, stubs: ['fieldMessages']})
+      it('if the value is between min and max', () => {
+        const result = wrapper.vm.isWithinRange()
+        expect(result).to.equal(false)
+      })
+    })
+    describe('should return false if range is (1, 9) and value is -1', () => {
+      propsData.field.range = {
+        min: 1,
+        max: 9
+      }
+      propsData.value = -1
+      const wrapper = mount(TypedFieldComponent, {propsData: propsData, stubs: ['fieldMessages']})
+      it('if the value is between min and max', () => {
+        const result = wrapper.vm.isWithinRange()
+        expect(result).to.equal(false)
+      })
     })
   })
 

--- a/test/unit/specs/util/EntityToFormMapper.spec.js
+++ b/test/unit/specs/util/EntityToFormMapper.spec.js
@@ -301,7 +301,6 @@ describe('Entity to state mapper', () => {
   })
 
   describe('Generate form fields and data for a [INT] attribute having a range property', () => {
-
     const form = EntityToFormMapper.generateForm(schemas.intSchemaWithRange, {})
     const field = form.formFields[0]
 
@@ -316,7 +315,6 @@ describe('Entity to state mapper', () => {
   })
 
   describe('Generate form fields and data for a [INT] attribute having only the min part of the range property', () => {
-
     const form = EntityToFormMapper.generateForm(schemas.intSchemaWithMinRange, {})
     const field = form.formFields[0]
 
@@ -330,7 +328,6 @@ describe('Entity to state mapper', () => {
   })
 
   describe('Generate form fields and data for a [INT] attribute having only the max part of the range property', () => {
-
     const form = EntityToFormMapper.generateForm(schemas.intSchemaWithMaxRange, {})
     const field = form.formFields[0]
 

--- a/test/unit/specs/util/EntityToFormMapper.spec.js
+++ b/test/unit/specs/util/EntityToFormMapper.spec.js
@@ -300,6 +300,49 @@ describe('Entity to state mapper', () => {
     })
   })
 
+  describe('Generate form fields and data for a [INT] attribute having a range property', () => {
+
+    const form = EntityToFormMapper.generateForm(schemas.intSchemaWithRange, {})
+    const field = form.formFields[0]
+
+    it('should map a [INT] attribute to a form field object', () => {
+      expect(field.type).to.equal('number')
+      expect(field.id).to.equal('integer')
+      expect(field.range).to.deep.equal({
+        min: 1,
+        max: 45
+      })
+    })
+  })
+
+  describe('Generate form fields and data for a [INT] attribute having only the min part of the range property', () => {
+
+    const form = EntityToFormMapper.generateForm(schemas.intSchemaWithMinRange, {})
+    const field = form.formFields[0]
+
+    it('should map a [INT] attribute to a form field object', () => {
+      expect(field.type).to.equal('number')
+      expect(field.id).to.equal('integer')
+      expect(field.range).to.deep.equal({
+        min: 1
+      })
+    })
+  })
+
+  describe('Generate form fields and data for a [INT] attribute having only the max part of the range property', () => {
+
+    const form = EntityToFormMapper.generateForm(schemas.intSchemaWithMaxRange, {})
+    const field = form.formFields[0]
+
+    it('should map a [INT] attribute to a form field object', () => {
+      expect(field.type).to.equal('number')
+      expect(field.id).to.equal('integer')
+      expect(field.range).to.deep.equal({
+        max: 45
+      })
+    })
+  })
+
   describe('Generate form fields and data for a [LONG] attribute', () => {
     const data = {
       'long': 2147483648

--- a/test/unit/specs/util/test-schemas.js
+++ b/test/unit/specs/util/test-schemas.js
@@ -255,6 +255,79 @@ export const intSchema = {
   ]
 }
 
+export const intSchemaWithRange = {
+  'attributes': [
+    {
+      'href': '/api/v2/it_emx_datatypes_TypeTest/meta/integer',
+      'fieldType': 'INT',
+      'name': 'integer',
+      'label': 'Integer Field',
+      'attributes': [],
+      'auto': false,
+      'nillable': false,
+      'readOnly': false,
+      'labelAttribute': true,
+      'unique': true,
+      'visible': true,
+      'lookupAttribute': true,
+      'isAggregatable': false,
+      'description': 'Integer description',
+      'range': {
+        'min': 1,
+        'max': 45
+      }
+    }
+  ]
+}
+
+export const intSchemaWithMinRange = {
+  'attributes': [
+    {
+      'href': '/api/v2/it_emx_datatypes_TypeTest/meta/integer',
+      'fieldType': 'INT',
+      'name': 'integer',
+      'label': 'Integer Field',
+      'attributes': [],
+      'auto': false,
+      'nillable': false,
+      'readOnly': false,
+      'labelAttribute': true,
+      'unique': true,
+      'visible': true,
+      'lookupAttribute': true,
+      'isAggregatable': false,
+      'description': 'Integer description',
+      'range': {
+        'min': 1
+      }
+    }
+  ]
+}
+
+export const intSchemaWithMaxRange = {
+  'attributes': [
+    {
+      'href': '/api/v2/it_emx_datatypes_TypeTest/meta/integer',
+      'fieldType': 'INT',
+      'name': 'integer',
+      'label': 'Integer Field',
+      'attributes': [],
+      'auto': false,
+      'nillable': false,
+      'readOnly': false,
+      'labelAttribute': true,
+      'unique': true,
+      'visible': true,
+      'lookupAttribute': true,
+      'isAggregatable': false,
+      'description': 'Integer description',
+      'range': {
+        'max': 45
+      }
+    }
+  ]
+}
+
 export const longSchema = {
   'attributes': [
     {


### PR DESCRIPTION
- number field ( can have a range object)
- range objects can have a min value, max value or both
- add custom validation messages for range ( min , max, both)
- remove type from fieldMessage properties
- add optional range property to fieldMessage component
- extend EntityMapper to include range property if set on INT of LONG type
- update readme
_ update and extend test data to include range

+
- fix flip flopping checkbox test