### PR TITLE
bump flatpicker ( datepicker) to version 7 

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@molgenis/molgenis-api-client": "^2.1.2",
     "moment": "^2.20.1",
     "vue-code": "^1.2.3",
-    "vue-flatpickr-component": "^6.1.0",
+    "vue-flatpickr-component": "^7.0.0",
     "vue-form": "^4.7.0",
     "vue-select": "^2.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3028,9 +3028,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flatpickr@^4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.2.4.tgz#abd6dedd0fa41e2118acb96a22f49819ba2d0157"
+flatpickr@^4.3.2:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.3.2.tgz#6a477043c075ef36c3ff54fadb49b936a64d635f"
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -7574,11 +7574,11 @@ vue-code@^1.2.3:
   dependencies:
     codemirror "5.x"
 
-vue-flatpickr-component@^6.1.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/vue-flatpickr-component/-/vue-flatpickr-component-6.2.0.tgz#911b70672de9dfe16adbe78e1ed83adc718133cb"
+vue-flatpickr-component@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vue-flatpickr-component/-/vue-flatpickr-component-7.0.0.tgz#ad7f9490db0048ce2c721f34ad0e5085a004e9ac"
   dependencies:
-    flatpickr "^4.2.4"
+    flatpickr "^4.3.2"
 
 vue-form@^4.7.0:
   version "4.7.1"


### PR DESCRIPTION
Version 6 had a bug that emitted lots of unused events on mount, this is not a good thing in large forms.