### PR TITLE
Fix #176 Message contains '[]' when select ( single /multi) has not options to show

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -68,7 +68,8 @@ module.exports = {
           'form_above_max_value': 'Value is above allowed value',
           'form_bool_true': 'True',
           'form_bool_false': 'False',
-          'form_bool_missing': 'N/A'
+          'form_bool_missing': 'N/A',
+          'form_no_options': 'No options found.'
         }
         res.json(localizedMessages)
       })

--- a/src/components/FormFieldComponent.vue
+++ b/src/components/FormFieldComponent.vue
@@ -69,7 +69,8 @@
         :isValid="isValid"
         :isRequired="isRequired"
         @dataChange="onDataChange"
-        :allowAddingOptions="formComponentOptions.allowAddingOptions">
+        :allowAddingOptions="formComponentOptions.allowAddingOptions"
+        :noOptionsMessage="noOptionsMessage">
       </multi-select-field-component>
     </template>
 
@@ -95,7 +96,8 @@
         :isRequired="isRequired"
         :isValid="isValid"
         @dataChange="onDataChange"
-        :allowAddingOptions="formComponentOptions.allowAddingOptions">
+        :allowAddingOptions="formComponentOptions.allowAddingOptions"
+        :noOptionsMessage="noOptionsMessage">
       </single-select-field-component>
     </template>
 
@@ -178,6 +180,8 @@
   import { FormField, FormComponentOptions } from '../flow.types'
   import isCompoundVisible from '../util/helpers/isCompoundVisible'
 
+  const defaultNoOptionsMessage = 'No options found for given search term.'
+
   export default {
     name: 'FormFieldComponent',
     props: {
@@ -233,6 +237,19 @@
           return isCompoundVisible(this.field, this.formData)
         }
         return (this.showOptionalFields || this.isRequired) && this.field.visible(this.formData)
+      },
+      noOptionsMessage () {
+        const msgKey = 'form_no_options'
+        const namespace = 'ui-form'
+
+        if (this.$t) {
+          const i18nMessage = this.$t(namespace + ':' + msgKey)
+          if (i18nMessage !== msgKey) {
+            return i18nMessage
+          }
+        }
+
+        return defaultNoOptionsMessage
       }
     },
     components: {

--- a/src/components/field-types/MultiSelectFieldComponent.vue
+++ b/src/components/field-types/MultiSelectFieldComponent.vue
@@ -1,4 +1,4 @@
-<template>
+  <template>
   <validate :state="fieldState" :custom="{'validate': isValid}">
     <div class="form-group">
       <label :for="field.id">{{ field.label }}</label>
@@ -18,7 +18,7 @@
                   :multiple="true">
 
           <div slot="no-options">
-            <small v-if="localValue">Option '{{ localValue }}' not found.</small>
+            <small>{{ noOptionsMessage }}</small>
           </div>
         </v-select>
 
@@ -80,6 +80,10 @@
         type: Boolean,
         required: false,
         default: false
+      },
+      noOptionsMessage: {
+        type: String,
+        required: false
       }
     },
     data () {

--- a/src/components/field-types/SingleSelectFieldComponent.vue
+++ b/src/components/field-types/SingleSelectFieldComponent.vue
@@ -16,7 +16,7 @@
                   :required="isRequired">
 
           <div slot="no-options">
-            <small v-if="localValue">Option '{{ localValue }}' not found.</small>
+            <small>{{ noOptionsMessage }}</small>
           </div>
         </v-select>
 
@@ -78,6 +78,10 @@
         type: Boolean,
         required: false,
         default: false
+      },
+      noOptionsMessage: {
+        type: String,
+        required: false
       }
     },
     data () {

--- a/test/unit/specs/FormFieldComponent.spec.js
+++ b/test/unit/specs/FormFieldComponent.spec.js
@@ -128,6 +128,50 @@ describe('FormFieldComponents unit tests', () => {
     })
   })
 
+  describe('noOptionsMessage constructs a message', () => {
+    const field = {
+      id: 'string',
+      type: 'text',
+      validate: (data) => data['string'] === 'data',
+      required: () => false,
+      visible: () => true
+    }
+
+    const propsData = {
+      formData: {'string': 'data'},
+      field: field,
+      formState: formState,
+      showOptionalFields: true
+    }
+
+    let wrapper
+
+    it('should return the default message is i18n message is not configured', () => {
+      wrapper = mount(FormFieldComponent, {propsData: propsData})
+      expect(wrapper.vm.noOptionsMessage).to.equal('No options found for given search term.')
+    })
+
+    it('should return the default message is i18n configured but no options messsage is set', () => {
+      wrapper = mount(FormFieldComponent, {
+        propsData: propsData,
+        mocks: {
+          $t: () => 'form_no_options'
+        }
+      })
+      expect(wrapper.vm.noOptionsMessage).to.equal('No options found for given search term.')
+    })
+
+    it('should return the i18n no options message if set', () => {
+      wrapper = mount(FormFieldComponent, {
+        propsData: propsData,
+        mocks: {
+          $t: (param) => param === 'ui-form:form_no_options' ? 'Message set' : 'No message set'
+        }
+      })
+      expect(wrapper.vm.noOptionsMessage).to.equal('Message set')
+    })
+  })
+
   describe('Hide optional fields', () => {
     const field = {
       id: 'string',


### PR DESCRIPTION
Fix 'no-options' message  support to use optional i18n message for single- and multi-select