### PR TITLE
Fix 195 Date field emits date-time even if only date part is set

### DIFF
--- a/src/components/field-types/DateFieldComponent.vue
+++ b/src/components/field-types/DateFieldComponent.vue
@@ -134,12 +134,7 @@
       localValue (value) {
         // Only emit a data change if the date is valid
         if (this.isValidDateTime(value)) {
-          // Emit value changes to the parent (form)
-          // Always emit a date value, not a string
-          this.$emit('input', this.getDateFromValue(value).toDate())
-
-          // Emit value changes to trigger the onValueChange
-          // Do not use input event for this to prevent unwanted behavior
+          this.$emit('input', value)
           this.$emit('dataChange')
         }
       }

--- a/test/unit/specs/field-types/DateFieldComponent.spec.js
+++ b/test/unit/specs/field-types/DateFieldComponent.spec.js
@@ -46,9 +46,9 @@ describe('DateFieldComponent', () => {
       const wrapper = mount(DateFieldComponent, {propsData: propsData})
 
       it('should emit an updated Date object on change', () => {
-        wrapper.setData({localValue: '2018-01-02'})
+        wrapper.setData({localValue: '2018-03-13'})
 
-        const expectedDateValue = moment('2018-01-02', 'YYYY-MM-DD').toDate()
+        const expectedDateValue = '2018-03-13'
 
         expect(wrapper.emitted().input[0]).to.deep.equal([expectedDateValue])
         expect(wrapper.emitted().dataChange[0]).to.deep.equal([])
@@ -108,7 +108,7 @@ describe('DateFieldComponent', () => {
       it('should emit an updated Date object including time on change', () => {
         wrapper.setData({localValue: '2018-01-02 13:37'})
 
-        const expectedDateTimeValue = moment('2018-01-02 13:37', 'YYYY-MM-DD HH:mm').toDate()
+        const expectedDateTimeValue = '2018-01-02 13:37'
 
         expect(wrapper.emitted().input[0]).to.deep.equal([expectedDateTimeValue])
         expect(wrapper.emitted().dataChange[0]).to.deep.equal([])


### PR DESCRIPTION
- On input emit date field as string (yyyy-mm-dd) instead of converting to date object

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [ ] Code unit/integration/system tested
- User documentation updated
- [x] Clean commits
- [x] No warnings during install
- Updated flow typing
