### PR TITLE
Fix/166 fix date en date-time field

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "debounce": "^1.1.0",
     "moment": "^2.20.1",
     "vue-code": "^1.2.3",
-    "vue-flatpickr-component": "^7.0.4",
+    "vue-flatpickr-component": "^8.0.0",
     "vue-form": "^4.10.1",
     "vue-select": "ConnorStroomberg/vue-select.git#release/patch-for-update-issue"
   },

--- a/src/components/field-types/DateFieldComponent.vue
+++ b/src/components/field-types/DateFieldComponent.vue
@@ -102,7 +102,6 @@
         config: {
           wrap: true,
           allowInput: true,
-          altInput: true,
           enableTime: this.isTimeIncluded,
           dateFormat: this.isTimeIncluded ? 'Z' : 'Y-m-d',
           altFormat: this.isTimeIncluded ? 'Y-m-d h:i K' : 'Y-m-d'

--- a/src/components/field-types/DateFieldComponent.vue
+++ b/src/components/field-types/DateFieldComponent.vue
@@ -103,8 +103,7 @@
           wrap: true,
           allowInput: true,
           enableTime: this.isTimeIncluded,
-          dateFormat: this.isTimeIncluded ? 'Z' : 'Y-m-d',
-          altFormat: this.isTimeIncluded ? 'Y-m-d h:i K' : 'Y-m-d'
+          dateFormat: this.isTimeIncluded ? 'Z' : 'Y-m-d'
         }
       }
     },

--- a/src/components/field-types/DateFieldComponent.vue
+++ b/src/components/field-types/DateFieldComponent.vue
@@ -102,7 +102,10 @@
         config: {
           wrap: true,
           allowInput: true,
-          enableTime: this.isTimeIncluded
+          altInput: true,
+          enableTime: this.isTimeIncluded,
+          dateFormat: this.isTimeIncluded ? 'Z' : 'Y-m-d',
+          altFormat: this.isTimeIncluded ? 'Y-m-d h:i K' : 'Y-m-d'
         }
       }
     },
@@ -115,7 +118,7 @@
        * @returns {Moment} A date object created by moment
        */
       getDateFromValue (dateString) {
-        const format = this.isTimeIncluded ? 'YYYY-MM-DD HH:mm' : 'YYYY-MM-DD'
+        const format = this.isTimeIncluded ? moment.ISO_8601 : 'YYYY-MM-DD'
         return moment(dateString, format, true)
       },
 

--- a/test/e2e/specs/field-render-tests.js
+++ b/test/e2e/specs/field-render-tests.js
@@ -96,6 +96,7 @@ module.exports = {
     browser.expect.element('#date').to.be.visible
 
     browser.click('#date')
+    browser.pause(500)
     browser.expect.element('.flatpickr-calendar').to.be.visible
 
     browser.click('.today')

--- a/test/e2e/specs/field-render-tests.js
+++ b/test/e2e/specs/field-render-tests.js
@@ -93,9 +93,9 @@ module.exports = {
   'Fill out date field using picker': function (browser) {
     browser.options.desiredCapabilities.name = 'Fill out date field using picker'
 
-    browser.expect.element('fieldset#date-fs').to.be.visible
+    browser.expect.element('#date').to.be.visible
 
-    browser.click('#date-fs > div > div > div.input-group > input.form-control.flatpickr-input.input')
+    browser.click('#date')
     browser.expect.element('.flatpickr-calendar').to.be.visible
 
     browser.click('.today')

--- a/test/e2e/specs/field-render-tests.js
+++ b/test/e2e/specs/field-render-tests.js
@@ -93,9 +93,9 @@ module.exports = {
   'Fill out date field using picker': function (browser) {
     browser.options.desiredCapabilities.name = 'Fill out date field using picker'
 
-    browser.expect.element('#date').to.be.visible
+    browser.expect.element('fieldset#date-fs').to.be.visible
 
-    browser.click('#date')
+    browser.click('#date-fs > div > div > div.input-group > input.form-control.flatpickr-input.input')
     browser.expect.element('.flatpickr-calendar').to.be.visible
 
     browser.click('.today')
@@ -123,9 +123,9 @@ module.exports = {
   'Fill out date time field using picker': function (browser) {
     browser.options.desiredCapabilities.name = 'Fill out date time field using picker'
 
-    browser.expect.element('#date_time').to.be.visible
+    browser.expect.element('fieldset#date_time-fs').to.be.visible
 
-    browser.click('#date_time')
+    browser.click('fieldset#date_time-fs')
     browser.expect.element('body > div.flatpickr-calendar.hasTime.animate.open').to.be.visible
 
     browser.click('body > div.flatpickr-calendar.hasTime.animate.open > div.flatpickr-innerContainer > div > div.flatpickr-days > div > span.flatpickr-day.today')

--- a/test/unit/specs/field-types/DateFieldComponent.spec.js
+++ b/test/unit/specs/field-types/DateFieldComponent.spec.js
@@ -133,7 +133,7 @@ describe('DateFieldComponent', () => {
       it('should return a moment object for a date string', () => {
         const date = '2018-01-02 13:37'
         const actual = wrapper.vm.getDateFromValue(date)
-        const expected = moment(date, 'YYYY-MM-DD HH:mm', true)
+        const expected = moment(date, moment.ISO_8601, true)
 
         expect(actual).to.deep.equal(expected)
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3043,9 +3043,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flatpickr@^4.4.6:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.5.1.tgz#f65eaf54c07538f87d6f68a67b03cf816d7fb82f"
+flatpickr@^4.5.1:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.5.2.tgz#47c8ad472a096e5fb7e74b809b0703535383f20d"
 
 flatten@^1.0.2:
   version "1.0.2"
@@ -7622,11 +7622,11 @@ vue-code@^1.2.3:
   dependencies:
     codemirror "5.x"
 
-vue-flatpickr-component@^7.0.4:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/vue-flatpickr-component/-/vue-flatpickr-component-7.0.4.tgz#29909596555f5160792a917f469f9e809e5e6c26"
+vue-flatpickr-component@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vue-flatpickr-component/-/vue-flatpickr-component-8.0.0.tgz#d5ce18981ad1c6fdf32106ae441f5160978e46b3"
   dependencies:
-    flatpickr "^4.4.6"
+    flatpickr "^4.5.1"
 
 vue-form@^4.10.1:
   version "4.10.1"


### PR DESCRIPTION
- Date field emits date as sting in "yyyy-mm-dd" format
- Date time emits date as ISO_8601 

Note: pretty date time format not working due to issue with vue, vue-from, vue-flatpicker interaction.
Need to create workaround (do pretty print in the description, format date_time in component) or have fix issue upstream ( vue-flatpicker altinput change, which is referring to flatpicker self)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- Clean commits - maybe rebase on master?
- [x] No warnings during install
- [x] Updated flow typing
