### PR TITLE
Trigger field validation when field becomes dirty

### DIFF
--- a/src/components/FormFieldMessages.vue
+++ b/src/components/FormFieldMessages.vue
@@ -1,5 +1,5 @@
 <template>
-  <field-messages :name="fieldId" :state="fieldState" show="$touched || $submitted" class="form-control-feedback">
+  <field-messages :name="fieldId" :state="fieldState" show="$touched || $submitted || $dirty" class="form-control-feedback">
     <div class="invalid-message" slot="required">{{ requiredFieldMsg }}</div>
     <div class="invalid-message" slot="email">{{ notAValidEmailMsg }}</div>
     <div class="invalid-message" slot="url">{{ notAValidUrlMsg }}</div>

--- a/src/components/field-types/CheckboxFieldComponent.vue
+++ b/src/components/field-types/CheckboxFieldComponent.vue
@@ -12,7 +12,7 @@
           type="checkbox"
           :name="field.id"
           class="form-check-input"
-          :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted) && fieldState.$invalid}"
+          :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted || fieldState.$dirty) && fieldState.$invalid}"
           :required="isRequired"
           :disabled="field.disabled">
         <label :for="field.id + '-' + index" class="form-check-label">{{ option.label }}</label>

--- a/src/components/field-types/CodeEditorFieldComponent.vue
+++ b/src/components/field-types/CodeEditorFieldComponent.vue
@@ -96,7 +96,8 @@
         return this.field.type === 'html' || lang === 'html' ? 'htmlmixed' : lang === 'python' || lang === 'javascript' ? lang : 'r'
       },
       isInvalid () {
-        return this.fieldState && ((this.fieldState.$touched || this.fieldState.$submitted) && (!this.isValid || (this.isRequired && this.localValue === '')))
+        return this.fieldState && ((this.fieldState.$touched || this.fieldState.$submitted || this.fieldState.$dirty) &&
+          (!this.isValid || (this.isRequired && this.localValue === '')))
       }
     },
     watch: {
@@ -107,6 +108,7 @@
         // Do not use input event for this to prevent unwanted behavior
         this.$emit('dataChange')
         this.fieldState.$touched = true
+        this.fieldState.$dirty = true
       }
     },
     components: {

--- a/src/components/field-types/DateFieldComponent.vue
+++ b/src/components/field-types/DateFieldComponent.vue
@@ -10,7 +10,7 @@
           :config="config"
           :name="field.id"
           class="form-control"
-          :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted) && fieldState.$invalid}"
+          :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted || fieldState.$dirty) && fieldState.$invalid}"
           :aria-describedby="field.id + '-description'"
           :required="isRequired"
           :disabled="field.disabled"

--- a/src/components/field-types/MultiSelectFieldComponent.vue
+++ b/src/components/field-types/MultiSelectFieldComponent.vue
@@ -7,7 +7,7 @@
 
         <v-select v-model="localValue"
                   class="form-control"
-                  :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted) && fieldState.$invalid}"
+                  :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted || fieldState.$dirty) && fieldState.$invalid}"
                   :options="options"
                   :onSearch="fetchOptions"
                   :filterable="false"

--- a/src/components/field-types/RadioFieldComponent.vue
+++ b/src/components/field-types/RadioFieldComponent.vue
@@ -12,7 +12,7 @@
           type="radio"
           :name="field.id"
           class="form-check-input"
-          :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted) && fieldState.$invalid}"
+          :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted || fieldState.$dirty) && fieldState.$invalid}"
           :required="isRequired"
           :disabled="field.disabled"
           :bool="localValue === true || localValue === false">

--- a/src/components/field-types/SingleSelectFieldComponent.vue
+++ b/src/components/field-types/SingleSelectFieldComponent.vue
@@ -7,7 +7,7 @@
 
         <v-select v-model="localValue"
                   class="form-control"
-                  :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted) && fieldState.$invalid}"
+                  :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted || fieldState.$dirty) && fieldState.$invalid}"
                   :options="options"
                   :onSearch="fetchOptions"
                   :filterable="false"

--- a/src/components/field-types/TextAreaFieldComponent.vue
+++ b/src/components/field-types/TextAreaFieldComponent.vue
@@ -8,7 +8,7 @@
         v-model="localValue"
         :name="field.id"
         class="form-control"
-        :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted) && fieldState.$invalid}"
+        :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted || fieldState.$dirty) && fieldState.$invalid}"
         :aria-describedby="field.id + '-description'"
         :required="isRequired"
         :disabled="field.disabled">
@@ -81,6 +81,7 @@
     },
     created () {
       debounceTime = this.inputDebounceTime
+      this.validationDebounce = debounceTime + 200 // validate after event update debounce
     }
   }
 </script>

--- a/src/components/field-types/TypedFieldComponent.vue
+++ b/src/components/field-types/TypedFieldComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <validate :state="fieldState" :custom="customValidation">
+  <validate :state="fieldState" :custom="customValidation" :debounce="validationDebounce">
     <div class="form-group">
       <label :for="field.id">{{ field.label }}</label>
 
@@ -9,7 +9,7 @@
         :type="inputType"
         :name="field.id"
         class="form-control"
-        :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted) && fieldState.$invalid}"
+        :class="{ 'is-invalid' : fieldState && (fieldState.$touched || fieldState.$submitted || fieldState.$dirty) && fieldState.$invalid}"
         :aria-describedby="field.id + '-description'"
         :required="isRequired"
         :disabled="field.disabled"
@@ -139,6 +139,7 @@
     },
     created () {
       debounceTime = this.inputDebounceTime
+      this.validationDebounce = debounceTime + 200 // validate after event update debounce
     }
   }
 </script>


### PR DESCRIPTION
- only validate after debounced value update

This solves the issue where by a form is invalid ( and maybe can not be saved) but the validation failure was not show because the field still has focus

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- [x] Clean commits
- [x] No warnings during install
- Updated flow typing (not relevant)
