### PR TITLE
fix null pointer due to missing parent component

### DIFF
--- a/test/unit/specs/FormFieldComponent.spec.js
+++ b/test/unit/specs/FormFieldComponent.spec.js
@@ -23,7 +23,8 @@ describe('FormFieldComponents unit tests', () => {
     formData: {'string': 'data'},
     field: field,
     formState: formState,
-    showOptionalFields: true
+    showOptionalFields: true,
+    eventBus: {}
   }
 
   const wrapper = shallow(FormFieldComponent, {
@@ -77,7 +78,8 @@ describe('FormFieldComponents unit tests', () => {
           ]
         },
         formState: formState,
-        showOptionalFields: true
+        showOptionalFields: true,
+        eventBus: {}
       }
 
       const wrapper = shallow(FormFieldComponent, {
@@ -116,7 +118,8 @@ describe('FormFieldComponents unit tests', () => {
       formData: {'string': 'data'},
       field: field,
       formState: formState,
-      showOptionalFields: true
+      showOptionalFields: true,
+      eventBus: {}
     }
 
     const wrapper = mount(FormFieldComponent, {
@@ -141,7 +144,8 @@ describe('FormFieldComponents unit tests', () => {
       formData: {'string': 'data'},
       field: field,
       formState: formState,
-      showOptionalFields: true
+      showOptionalFields: true,
+      eventBus: {}
     }
 
     let wrapper
@@ -185,7 +189,8 @@ describe('FormFieldComponents unit tests', () => {
       formData: {'string': 'data'},
       field: field,
       formState: formState,
-      showOptionalFields: false
+      showOptionalFields: false,
+      eventBus: {}
     }
 
     const wrapper = mount(FormFieldComponent, {
@@ -215,10 +220,11 @@ describe('FormFieldComponents unit tests', () => {
       formData: {'string': 'data', id: 'abc'},
       field: field,
       formState: formState,
-      showOptionalFields: false
+      showOptionalFields: false,
+      eventBus: {}
     }
 
-    const wrapper = mount(FormFieldComponent, {
+    const wrapper = shallow(FormFieldComponent, {
       propsData: propsData
     })
 


### PR DESCRIPTION
Use shallow mocking to avoid null pointer due to parent component reference

- Add expected eventBus stub

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Updated flow typing
