### PR TITLE
[Fix 233] Set the value to null on clearing a number field

### DIFF
--- a/src/components/field-types/TypedFieldComponent.vue
+++ b/src/components/field-types/TypedFieldComponent.vue
@@ -81,16 +81,19 @@
     },
     watch: {
       localValue: debounce(function (value) {
-        if (this.isNumberField && !Number.isNaN(Number(value))) {
-          this.$emit('input', Number(value))
-        } else {
-          this.$emit('input', value)
-        }
+        let typedValue = this.isNumberField && !Number.isNaN(Number(value)) ? this.toNumber(value) : value
+
+        this.$emit('input', typedValue)
 
         // Emit value changes to trigger the onValueChange
         // Do not use input event for this to prevent unwanted behavior
         this.$emit('dataChange')
       }, debounceTime)
+    },
+    methods: {
+      toNumber (input) {
+        return input !== '' ? Number(input) : null
+      }
     },
     computed: {
       stepSize () {
@@ -101,11 +104,11 @@
         return this.isNumberField ? 'number' : this.field.type
       },
       isValidRange () {
-        if (!this.isNumberField || !this.field.range) {
+        if (!this.isNumberField || !this.field.range || this.localValue === '') {
           return true
         }
 
-        const numberValue = Number(this.localValue)
+        const numberValue = this.toNumber(this.localValue)
         if (Number.isNaN(numberValue)) {
           return false
         }
@@ -119,7 +122,7 @@
         return true
       },
       isValidInt () {
-        if (this.field.type !== 'integer') {
+        if (this.field.type !== 'integer' || this.localValue === '') {
           return true
         }
 
@@ -130,7 +133,7 @@
         return Number.isSafeInteger(numberValue) && numberValue <= MAX_JAVA_INT && numberValue >= MIN_JAVA_INT
       },
       isValidLong () {
-        if (this.field.type !== 'long') {
+        if (this.field.type !== 'long' || this.localValue === '') {
           return true
         }
         const numberValue = Number(this.localValue)

--- a/src/example/components/ModelSettings.vue
+++ b/src/example/components/ModelSettings.vue
@@ -9,7 +9,7 @@
       <hr/>
 
       <h5 class="card-title">data</h5>
-        <pre>{{ fieldData }}</pre>
+        <pre class="field-data-json">{{ fieldData }}</pre>
     </div>
   </div>
 

--- a/test/e2e/specs/integer-field-test.js
+++ b/test/e2e/specs/integer-field-test.js
@@ -33,5 +33,26 @@ module.exports = {
     browser.expect.element('.invalid-message').to.be.present
     browser.expect.element('.invalid-message').text.to.be.equal('Not a valid integer value')
     browser.end()
+  },
+
+  'Clearing the value should place "null" in the model': function (browser) {
+    browser.options.desiredCapabilities.name = 'Integer field not valid for decimal value'
+    browser.expect.element('#integer-example input[type=number]').to.be.present
+
+    browser.click('#integer-example input[type=number]') // https://github.com/nightwatchjs/nightwatch/issues/504
+
+    // Send backspace as workaround for nightwatch clearValue issues
+    browser.setValue('#integer-example input[type=number]', '\u0008')
+
+    browser.keys(browser.Keys.TAB)
+    browser.click('h5.card-header.text-center') // click outside of input to trigger validation
+    browser.pause(1000)
+
+    browser.expect.element('#integer-example input[type=number]').to.have.attribute('class').which.contains('vf-valid')
+    browser.getText('.field-data-json', function (result) {
+      this.assert.equal(JSON.parse(result.value)['integer-example'], null)
+    })
+
+    browser.end()
   }
 }

--- a/test/unit/specs/field-types/TypedFieldComponent.spec.js
+++ b/test/unit/specs/field-types/TypedFieldComponent.spec.js
@@ -156,10 +156,18 @@ describe('TypedFieldComponent unit tests', () => {
       )
     })
 
-    it('should emit an updated integer if value us valid integer on change', (done) => {
+    it('should emit an updated integer if value is valid integer on change', (done) => {
       wrapper.setData({localValue: '1'})
       setTimeout(function () {
         expect(wrapper.emitted().input[0]).to.deep.equal([1])
+        done()
+      }, 1000)
+    })
+
+    it('should emit null if value empty on change', (done) => {
+      wrapper.setData({localValue: ''})
+      setTimeout(function () {
+        expect(wrapper.emitted().input[0]).to.deep.equal([null])
         done()
       }, 1000)
     })


### PR DESCRIPTION
Fix #234 Can not clear number (int/long/decimal) fields

- Add class to example dataModel tag add hook for test code
- Add e2e test to test clearing on multiple browsers

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Clean commits
- [x] No warnings during install
- [x] Updated flow typing
