### PR TITLE
fix: Put a non-breaking space between label and asterisk

### DIFF
--- a/src/components/FormFieldComponent.vue
+++ b/src/components/FormFieldComponent.vue
@@ -136,8 +136,9 @@
 </template>
 
 <style>
+  /* Adds asterisk to required fields. The \a0 is a non-breaking space */
   fieldset.required-field > div > div.form-group > label::after {
-    content: ' *';
+    content: '\a0*';
   }
 
   /*  Styling to have v-select look like bootstrap field */

--- a/src/formDemoMockResponse.js
+++ b/src/formDemoMockResponse.js
@@ -75,7 +75,7 @@ const metadata = {
       'href': '/api/v2/it_emx_datatypes_TypeTest/meta/integer',
       'fieldType': 'INT',
       'name': 'integer',
-      'label': 'Integer Field',
+      'label': 'Integer Field that, to test line wrapping, is supercalifragilisticexpialidocious',
       'attributes': [],
       'auto': false,
       'nillable': false,


### PR DESCRIPTION
For required fields, the css adds an asterisk after the label.
Use escaped unicode character because the html entities do not work inside css, see https://stackoverflow.com/questions/190396/adding-html-entities-using-css-content.

Fixes #244: Asterisk for required form sometimes ends up on separate line

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [ ] Code unit/integration/system tested
- [x] User documentation updated
- [x] Clean commits
- [x] No warnings during install
- [ ] Updated flow typing
