### PR TITLE
Fix #184: Forms behaviour on some nullable fields not as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 <a name="next release"></a>
 ## next release (xx-xx-xxxx)
-### Features
-### Bugfixes
 
-<a name="2.1.1"></a>
-## 2.1.1 (xx-xx-xxxx)
+### Breaking changes
+The mapper option `showNillableBooleanOption` is removed, the N/A option is now added to any radio
+field whenever it is required. This takes the current value of a nullable expressions into account.
+
 ### Bugfixes
 * [#255 Auto generated dates not working](https://github.com/molgenis/molgenis-ui-form/issues/255)
 * [#254 No way to figure out if radio button values have changed](https://github.com/molgenis/molgenis-ui-form/issues/254)

--- a/README.md
+++ b/README.md
@@ -362,7 +362,6 @@ If no 'ui-form' namespace is set on the supplied Vue instance the default (Engli
 The `EntityToFormMapper.generateForm` function takes a *optional* `options` param.
 The options param is a object that can contain the following properties:
 - `booleanLabels` Optional Object used to set labels for boolean type fields, can be use in combination with i18n plugin to translate boolean labels.
-- `showNillableBooleanOption` Optional boolean that hides 'N/A' option for nillable boolean is set to `false`, defaults to true
 - `showNonVisibleAttributes` Optional boolean if set to true maps non visible attributes to visible field, defaults to false
 - `mapperMode` Optional string (valid modes are `UPDATE` and `CREATE`) if set to `CREATE` readonly attributes map to writable fields, defaults to `CREATE`
 ## Development

--- a/config/index.js
+++ b/config/index.js
@@ -74,7 +74,9 @@ module.exports = {
           'form_boolean_missing': 'N/A',
           'form_no_options': 'No options found.',
           'form_hide_optional_hint': 'Hide optional fields.',
-          'form_show_optional_hint': 'Show all fields.'
+          'form_show_optional_hint': 'Show all fields.',
+          'form_file_change': 'Change',
+          'form_file_browse': 'Browse',
         }
         res.json(localizedMessages)
       })

--- a/src/components/field-types/FileFieldComponent.vue
+++ b/src/components/field-types/FileFieldComponent.vue
@@ -15,17 +15,15 @@
       >
         {{ field.label }}
       </label>
-      <div class="custom-file">
-        <label class="custom-file-label" :for="field.id">
-          {{ label }}
-        </label>
-
+      <div class="custom-file" @click="clear">
         <input
           :required="isRequired"
           class="custom-file-input"
           type="file"
           @change="handleFileChange"/>
+        <label class="custom-file-label" :for="field.id" :data-browse="buttonText">{{ label }}</label>
       </div>
+
 
       <small :id="field.id + '-description'" class="form-text text-muted">
         {{ field.description }}
@@ -77,7 +75,23 @@
         localValue: this.value
       }
     },
+    watch: {
+      value (value) {
+        this.localValue = value
+      }
+    },
     methods: {
+      clear () {
+        this.fieldState.$touched = true
+        this.fieldState.$untouched = false
+        if (this.isRequired) {
+          return
+        }
+        this.localValue = null
+        this.$emit('input', this.localValue)
+        this.fieldState.$dirty = true
+        this.fieldState.$pristine = false
+      },
       handleFileChange (e) {
         // Whenever the file changes, emit the 'input' event with the file data.
         this.localValue = e.target.files[0]
@@ -90,9 +104,13 @@
       }
     },
     computed: {
+      buttonText () {
+        const key = this.localValue ? 'ui-form:form_file_change' : 'ui-form:form_file_browse'
+        return this.$t ? this.$t(key) : key
+      },
       label () {
-        return typeof this.value === 'string' ? this.value
-          : this.value instanceof Blob ? this.value.name : ''
+        return typeof this.localValue === 'string' ? this.localValue
+          : this.localValue instanceof Blob ? this.localValue.name : ''
       }
     }
   }

--- a/src/components/field-types/RadioFieldComponent.vue
+++ b/src/components/field-types/RadioFieldComponent.vue
@@ -19,6 +19,16 @@
           :bool="localValue === true || localValue === false">
         <label :for="field.id + '-' + index" class="form-check-label">{{ option.label }}</label>
       </div>
+      <div class="form-check" v-if="!isRequired">
+        <input
+          :id="field.id + '-null'"
+          v-model="localValue"
+          type="radio"
+          class="form-check-input"
+          :name="field.id"
+          :value="null">
+        <label :for="field.id + '-null'" class="form-check-label">{{ nullOptionLabel }}</label>
+      </div>
 
       <small :id="field.id + '-description'" class="form-text text-muted">
         {{ field.description }}
@@ -74,6 +84,11 @@
         // Store a local value to prevent changing the parent state
         localValue: this.value,
         options: []
+      }
+    },
+    computed: {
+      nullOptionLabel () {
+        return this.$t ? this.$t('ui-form:form_boolean_missing') : 'form_boolean_missing'
       }
     },
     watch: {

--- a/src/example/entity/CreateEntityExample.vue
+++ b/src/example/entity/CreateEntityExample.vue
@@ -85,8 +85,7 @@
       const mapperOptions = {
         booleanLabels: {
           trueLabel: this.$t('form_boolean_true'), // $t is set via @molgenis/molgenis-i18n-js plugin
-          falseLabel: this.$t('form_boolean_false'),
-          nillLabel: this.$t('form_boolean_missing')
+          falseLabel: this.$t('form_boolean_false')
         },
         mapperMode: 'CREATE'
       }

--- a/src/example/entity/UpdateEntityExample.vue
+++ b/src/example/entity/UpdateEntityExample.vue
@@ -85,8 +85,7 @@
       const mapperOptions = {
         booleanLabels: {
           trueLabel: this.$t('form_boolean_true'), // $t is set via @molgenis/molgenis-i18n-js plugin
-          falseLabel: this.$t('form_boolean_false'),
-          nillLabel: this.$t('form_boolean_missing')
+          falseLabel: this.$t('form_boolean_false')
         }
       }
       const form = EntityToFormMapper.generateForm(EntityTypeV2Response.metadata, EntityTypeV2Response.items, mapperOptions)

--- a/src/example/file/FileExample.vue
+++ b/src/example/file/FileExample.vue
@@ -16,6 +16,10 @@
             </form-component>
           </div>
         </div>
+        <div class="custom-control custom-switch">
+          <input type="checkbox" class="custom-control-input" id="nillable" v-model="nillable">
+          <label class="custom-control-label" for="nillable">required</label>
+        </div>
       </div>
 
       <div class="col-sm">
@@ -56,6 +60,16 @@
         formState: {},
         formData: {
           'file-example': 'test-file-name.txt'
+        }
+      }
+    },
+    computed: {
+      nillable: {
+        get: function () {
+          return this.formFields[0].required()
+        },
+        set: function (newValue) {
+          this.formFields[0].required = () => newValue
         }
       }
     },

--- a/src/flow.types.js
+++ b/src/flow.types.js
@@ -43,10 +43,8 @@ export type MapperOptions = {
   mapperMode?: MapperMode,
   booleanLabels?: {
     trueLabel: string,
-    falseLabel: string,
-    nillLabel: string
+    falseLabel: string
   },
-  showNillableBooleanOption?: boolean,
   showNonVisibleAttributes?: boolean
 }
 
@@ -57,10 +55,8 @@ export type MapperSettings = {
   mapperMode: MapperMode,
   booleanLabels: {
     trueLabel: string,
-    falseLabel: string,
-    nillLabel: string
+    falseLabel: string
   },
-  showNillableBooleanOption: boolean,
   showNonVisibleAttributes: boolean
 }
 

--- a/src/util/EntityToFormMapper.js
+++ b/src/util/EntityToFormMapper.js
@@ -21,10 +21,8 @@ const DEFAULTS = {
   mapperMode: 'UPDATE',
   booleanLabels: {
     trueLabel: 'True',
-    falseLabel: 'False',
-    nillLabel: 'N/A'
+    falseLabel: 'False'
   },
-  showNillableBooleanOption: true,
   showNonVisibleAttributes: false
 }
 
@@ -142,22 +140,12 @@ const getFieldOptions = (attribute, options: MapperSettings): ?(() => Promise<Ar
           label: option
         }
       })
-
-      if (attribute.nillable) {
-        enumOptions.push({id: 'null', value: 'null', label: 'N/A'})
-      }
-
       return (): Promise<Array<FieldOption>> => Promise.resolve(enumOptions)
     case 'BOOL':
       const boolOptions = [
         {id: 'true', value: true, label: options.booleanLabels.trueLabel},
         {id: 'false', value: false, label: options.booleanLabels.falseLabel}
       ]
-
-      if (attribute.nillable && options.showNillableBooleanOption) {
-        boolOptions.push({id: 'null', value: null, label: options.booleanLabels.nillLabel})
-      }
-
       return (): Promise<Array<FieldOption>> => Promise.resolve(boolOptions)
     default:
       return null
@@ -468,7 +456,7 @@ const generateFormFields = (metaData: any, options: MapperSettings): Array<FormF
 /**
  * Construct mapper settings taking into account the user settings, if no settings are passed the defaults are used
  * @param settings
- * @returns {{mapperMode: *, booleanLabels: {trueLabel: string, falseLabel: string, nillLabel: string}, showNillableBooleanOption: boolean}}
+ * @returns {{mapperMode: *, booleanLabels: {trueLabel: string, falseLabel: string, nillLabel: string}}}
  */
 const buildMapperSettings = (settings?: MapperOptions): MapperSettings => {
   if (!settings) {
@@ -481,14 +469,8 @@ const buildMapperSettings = (settings?: MapperOptions): MapperSettings => {
   if (settings.booleanLabels) {
     booleanLabels = {
       trueLabel: settings.booleanLabels.trueLabel ? settings.booleanLabels.trueLabel : 'True',
-      falseLabel: settings.booleanLabels.falseLabel ? settings.booleanLabels.falseLabel : 'False',
-      nillLabel: settings.booleanLabels.nillLabel ? settings.booleanLabels.nillLabel : 'N/A'
+      falseLabel: settings.booleanLabels.falseLabel ? settings.booleanLabels.falseLabel : 'False'
     }
-  }
-
-  let showNillableBooleanOption = DEFAULTS.showNillableBooleanOption
-  if (typeof (settings.showNillableBooleanOption) === 'boolean') {
-    showNillableBooleanOption = settings.showNillableBooleanOption
   }
 
   let showNonVisibleAttributes = DEFAULTS.showNonVisibleAttributes
@@ -499,7 +481,6 @@ const buildMapperSettings = (settings?: MapperOptions): MapperSettings => {
   return {
     mapperMode,
     booleanLabels,
-    showNillableBooleanOption,
     showNonVisibleAttributes
   }
 }

--- a/test/e2e/specs/file-field-test.js
+++ b/test/e2e/specs/file-field-test.js
@@ -11,9 +11,9 @@ module.exports = {
 
   'File field should show the file name': function (browser) {
     browser.options.desiredCapabilities.name = 'File field should show the file name'
-    browser.expect.element('#file-example-fs > div > div > div.custom-file > input').to.be.present
+    browser.expect.element('#file-example-fs div.custom-file > input').to.be.present
     // bootstrap uses label to fake file input value
-    browser.expect.element('#file-example-fs > div > div > div.custom-file > label').text.to.contain('test-file-name.txt')
+    browser.expect.element('#file-example-fs div.custom-file > label').text.to.contain('test-file-name.txt')
     browser.end()
   },
 
@@ -21,12 +21,11 @@ module.exports = {
     // Skip set file test for safari as safari does not allow to post a file
     if (browser.options.desiredCapabilities.browserName !== 'safari') {
       browser.options.desiredCapabilities.name = 'File field allow selecting a file'
-      browser.expect.element('#file-example-fs > div > div > div.custom-file > input').to.be.present
+      browser.expect.element('#file-example-fs div.custom-file > input').to.be.present
       // bootstrap uses label to fake file input value
-      browser.uploadFile(path.resolve(path.join(__dirname, 'file-field-test.js')), '#file-example-fs > div > div > div.custom-file > input')
-      browser.expect.element('#file-example-fs > div').to.have.attribute('class').which.contains('vf-field-dirty vf-field-valid vf-field-touched')
+      browser.uploadFile(path.resolve(path.join(__dirname, 'file-field-test.js')), '#file-example-fs div.custom-file > input')
+      browser.expect.element('#file-example-fs div.vf-field-dirty.vf-field-valid.vf-field-touched').to.be.present
       browser.end()
     }
   }
-
 }

--- a/test/e2e/specs/radio-field-test.js
+++ b/test/e2e/specs/radio-field-test.js
@@ -8,6 +8,17 @@ module.exports = {
     browser.url(browser.globals.devServerURL + '/radio')
   },
 
+  'Deselect radio option': function (browser) {
+    browser.options.desiredCapabilities.name = 'Deselect radio option'
+    browser.click('#nillable + label')
+    browser.expect.element('#radio-example-null').to.be.present
+    browser.expect.element('#radio-example-null').to.be.selected
+    browser.expect.element('#radio-example-null + label').text.to.equal('N/A')
+    browser.click('label.form-check-label')
+    browser.expect.element('#radio-example-null').not.to.be.selected
+    browser.end()
+  },
+
   'Select radio option': function (browser) {
     browser.options.desiredCapabilities.name = 'Select radio option'
     browser.expect.element('#radio-example-form').to.be.present
@@ -16,7 +27,7 @@ module.exports = {
     browser.click('label.form-check-label')
     browser.expect.element('#radio-example-form.vf-form-touched.vf-form-dirty').to.be.present
     browser.expect.element('#radio-example-0.vf-touched.vf-dirty').to.be.present
-    browser.getValue('input[name="radio-example"]:checked', function (result) {
+    browser.getValue('input[name="radio-example"]', function (result) {
       this.assert.equal(result.value, 1)
     })
     browser.end()

--- a/test/unit/specs/field-types/FileFieldComponent.spec.js
+++ b/test/unit/specs/field-types/FileFieldComponent.spec.js
@@ -24,7 +24,7 @@ describe('FileFieldComponent unit tests', () => {
   const propsData = {
     field: field,
     fieldState: fieldState,
-    isRequired: true,
+    isRequired: false,
     isValid: true
   }
 
@@ -32,6 +32,7 @@ describe('FileFieldComponent unit tests', () => {
     propsData: propsData,
     stubs: {'fieldMessages': '<div>This field is required</div>'}
   })
+  wrapper.vm.$t = (x) => x
 
   it('should render a an empty label when no initial value is set', () => {
     expect(wrapper.vm.label).to.equal('')
@@ -53,6 +54,34 @@ describe('FileFieldComponent unit tests', () => {
     expect(wrapper.vm.label).to.equal('new_file.zip')
   })
 
+  it('should render the correct button text when a file is selected', () => {
+    propsData.value = 'file.zip'
+    wrapper.setProps(propsData)
+    expect(wrapper.vm.buttonText).to.equal('ui-form:form_file_change')
+  })
+
+  it('should render the correct button text when no file is selected', () => {
+    propsData.value = null
+    wrapper.setProps(propsData)
+    expect(wrapper.vm.buttonText).to.equal('ui-form:form_file_browse')
+  })
+
+  it('should clear file input if the field is nillable', () => {
+    expect(wrapper.vm.isRequired).to.equal(false)
+    wrapper.vm.clear()
+    expect(wrapper.vm.label).to.equal('')
+    expect(wrapper.emitted().input.slice(-1)[0]).deep.equal([null])
+  })
+
+  it('should not clear file input if the field is required', () => {
+    propsData.isRequired = true
+    propsData.value = 'file.zip'
+    wrapper.setProps(propsData)
+    expect(wrapper.vm.isRequired).to.equal(true)
+    wrapper.vm.clear()
+    expect(wrapper.vm.label).to.equal('file.zip')
+  })
+
   it('should emit change when the file input is updated', () => {
     const event = {
       target: {
@@ -61,8 +90,7 @@ describe('FileFieldComponent unit tests', () => {
         ]
       }
     }
-
     wrapper.vm.handleFileChange(event)
-    expect(wrapper.emitted().input[0]).deep.equal(['file'])
+    expect(wrapper.emitted().input.slice(-1)[0]).deep.equal(['file'])
   })
 })

--- a/test/unit/specs/field-types/RadioFieldComponent.spec.js
+++ b/test/unit/specs/field-types/RadioFieldComponent.spec.js
@@ -56,6 +56,7 @@ describe('RadioFieldComponent unit tests', () => {
       stubs: {'fieldMessages': '<div>This field is required</div>'}
     }
   )
+  wrapper.vm.$t = (x) => x
 
   it('should render an input for every option', () => {
     const inputs = wrapper.findAll('input')
@@ -65,9 +66,29 @@ describe('RadioFieldComponent unit tests', () => {
     expect(inputs.at(2).element.id).to.equal('radio-field-2')
   })
 
-  it('should emit an updated value and set fieldState on change', () => {
+  it('should render an N/A option when nullable', () => {
+    propsData.isRequired = false
+    wrapper.setProps(propsData)
+    const inputs = wrapper.findAll('input')
+    const input = inputs.at(3)
+    const element = input.element
+    expect(element.id).to.equal('radio-field-null')
+    element.checked = true
+    input.trigger('click')
+    input.trigger('change')
+    expect(wrapper.emitted().input.slice(-1)[0]).to.deep.equal([null])
+    expect(wrapper.vm.localValue).to.equal(null)
+  })
+
+  it('should render the form_bool_missing text as option label', () => {
+    propsData.isRequired = false
+    wrapper.setProps(propsData)
+    expect(wrapper.find("label[for='radio-field-null']").text()).to.equal('ui-form:form_boolean_missing')
+  })
+
+  it('should emit an updated value and set the fieldState on change', () => {
     wrapper.setData({localValue: '1'})
-    expect(wrapper.emitted().input[0]).to.deep.equal(['1'])
+    expect(wrapper.emitted().input.slice(-1)[0]).to.deep.equal(['1'])
     expect(fieldState.$touched).to.equal(true)
     expect(fieldState.$untouched).to.equal(false)
     expect(fieldState.$dirty).to.equal(true)

--- a/test/unit/specs/util/EntityToFormMapper.spec.js
+++ b/test/unit/specs/util/EntityToFormMapper.spec.js
@@ -237,29 +237,6 @@ describe('Entity to state mapper', () => {
       field.options().then(response => {
         expect(response).to.deep.equal([
           {id: 'true', value: true, label: 'True'},
-          {id: 'false', value: false, label: 'False'},
-          {id: 'null', value: null, label: 'N/A'}
-        ])
-        done()
-      })
-    })
-
-    it('should hide \'N/A\' option for nillable [BOOLEAN] attribute is mapperOptions.showNillableBooleanOption is set to false', done => {
-      const data = null
-      const mapperOptions = {
-        showNillableBooleanOption: false
-      }
-      const form = EntityToFormMapper.generateForm(schemas.booleanSchemaNillable, data, mapperOptions)
-      const field = form.formFields[0]
-
-      expect(field.type).to.equal('radio')
-      expect(field.id).to.equal('boolean')
-      expect(field.visible()).to.equal(true)
-      expect(typeof field.options).to.equal('function')
-
-      field.options().then(response => {
-        expect(response).to.deep.equal([
-          {id: 'true', value: true, label: 'True'},
           {id: 'false', value: false, label: 'False'}
         ])
         done()
@@ -270,8 +247,7 @@ describe('Entity to state mapper', () => {
       const options = {
         booleanLabels: {
           trueLabel: 'oui',
-          falseLabel: 'non',
-          nillLabel: 'inconnu'
+          falseLabel: 'non'
         }
       }
       const form = EntityToFormMapper.generateForm(schemas.booleanSchemaNillable, {}, options)
@@ -289,8 +265,7 @@ describe('Entity to state mapper', () => {
       field.options().then(response => {
         expect(response).to.deep.equal([
           {id: 'true', value: true, label: 'oui'},
-          {id: 'false', value: false, label: 'non'},
-          {id: 'null', value: null, label: 'inconnu'}
+          {id: 'false', value: false, label: 'non'}
         ])
         done()
       })
@@ -556,8 +531,7 @@ describe('Entity to state mapper', () => {
         expect(response).to.deep.equal([
           {id: 'enum1', value: 'enum1', label: 'enum1'},
           {id: 'enum2', value: 'enum2', label: 'enum2'},
-          {id: 'enum3', value: 'enum3', label: 'enum3'},
-          {id: 'null', value: 'null', label: 'N/A'}
+          {id: 'enum3', value: 'enum3', label: 'enum3'}
         ])
         done()
       })


### PR DESCRIPTION
Two separate issues really:

# Nillable radio buttons

## Current behavior
Currently an N/A option gets added statically by the mapper when it converts metadata to form schema. The value of nillable expression does not get taken into account.
### BOOL
i18n value of `form_boolean_missing` is added when `attribute.nillable` is false and global mapper option `showNillableBooleanOption` is true
### ENUM
string `N/A` is always added when`attribute.nillable` is false
### CATEGORICAL
`N/A` is never added (the reported bug)

## Fixed behavior
The Radio field component adds i18n value of `form_boolean_missing` when the field is currently not required. This is takes the current value of any nillableExpression into account.

The idea is that whatever the radio buttons represent, you should be able to clear them if the field is not required. The visibleExpression means that you cannot add this option at mapping time because the field may become required when you fill in the form. (This happens for example in the c6 questionnaire.)

# Nillable files 
I've added a clear button.
The localValue was not used to determine the label, the prop was used instead. I've changed that to get better testability.

Fixes #215 

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Updated flow typing
