### PR TITLE
Fix #291 Cannot add new rows in molgenis for tables with mrefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="unreleased"></a>
+## unreleased (xx-xx-xxxx)
+
+### Breaking
+
+### Features
+
+### Bugfixes
+
+<a name="3.0.2"></a>
+## 3.0.2 (25-04-2019)
+
+### Bugfixes
+* [#291 Cannot add new rows in molgenis for tables with ](https://github.com/molgenis/molgenis-ui-form/issues/291)
+
 <a name="3.0.1"></a>
 ## 3.0.1 (24-04-2019)
 

--- a/src/util/EntityToFormMapper.js
+++ b/src/util/EntityToFormMapper.js
@@ -10,6 +10,7 @@ import type {
 } from '../flow.types'
 
 import evaluator from './helpers/evaluator'
+import UriGenerator from './helpers/uriGenerator'
 // $FlowFixMe
 import api from '@molgenis/molgenis-api-client'
 // $FlowFixMe
@@ -55,17 +56,7 @@ const fetchFieldOptions = (refEntity: RefEntityType, search: ?string | ?Array<st
   // map refEntity.hrefCollection v1 URLs to v2 to enable the use of RSQL queries
   let uri = refEntity.hrefCollection.replace('/v1/', '/v2/')
 
-  if (search) {
-    if (Array.isArray(search)) {
-      // Join array into a string
-      const value = search.join(',')
-      // Use =in= query
-      uri = uri + '?q=' + idAttribute + '=in=(' + value + '),' + labelAttribute + '=in=(' + value + ')'
-    } else if (typeof search === 'string') {
-      const value = search
-      uri = uri + '?q=' + idAttribute + '=like=' + value + ',' + labelAttribute + '=like=' + value
-    }
-  }
+  uri = UriGenerator.generateUri(search, uri, idAttribute, labelAttribute)
 
   return api.get(uri).then(response => {
     return response.items.map(item => {

--- a/src/util/helpers/uriGenerator.js
+++ b/src/util/helpers/uriGenerator.js
@@ -18,5 +18,5 @@ const generateUri = (
 }
 
 export default {
-  generateUri,
+  generateUri
 }

--- a/src/util/helpers/uriGenerator.js
+++ b/src/util/helpers/uriGenerator.js
@@ -1,0 +1,22 @@
+// @flow
+
+const generateUri = (
+  search: ?string | ?Array<string>, uri: string, idAttribute: string,
+  labelAttribute: string) => {
+  if (search) {
+    if (Array.isArray(search) && search.length > 0) {
+      // Join array into a string
+      const value = search.join(',')
+      // Use =in= query
+      uri = `${uri}?q=${idAttribute}=in=(${value}),${labelAttribute}=in=(${value})`
+    } else if (typeof search === 'string') {
+      const value = search
+      uri = `${uri}?q=${idAttribute}=like=${value},${labelAttribute}=like=${value}`
+    }
+  }
+  return uri
+}
+
+export default {
+  generateUri,
+}

--- a/test/unit/specs/util/helpers/uriGenerator.spec.js
+++ b/test/unit/specs/util/helpers/uriGenerator.spec.js
@@ -1,0 +1,38 @@
+import uriGenerator from '@/util/helpers/uriGenerator'
+
+describe('uriGenerator', () => {
+  const uri = '/api/v2/tablename'
+  const id = 'idAttr'
+  const label = 'labelAttr'
+
+  it('should generate an uri without query when there is no search string',
+    () => {
+      const search = null
+      const result = uriGenerator.generateUri(search, uri, id, label)
+      expect(result).to.equal(uri)
+    })
+
+  it('should generate an uri with like query when there is a search string',
+    () => {
+      const search = 'blaat'
+      const result = uriGenerator.generateUri(search, uri, id, label)
+      const expected = `${uri}?q=${id}=like=${search},${label}=like=${search}`
+      expect(result).to.equal(expected)
+    })
+
+  it('should generate an uri with in query when there is a search array',
+    () => {
+      const search = ['blaat1', 'blaat2']
+      const searchString = 'blaat1,blaat2'
+      const result = uriGenerator.generateUri(search, uri, id, label)
+      const expected = `${uri}?q=${id}=in=(${searchString}),${label}=in=(${searchString})`
+      expect(result).to.equal(expected)
+    })
+
+  it('should generate an uri without query when there is an empty search array',
+    () => {
+      const search = []
+      const result = uriGenerator.generateUri(search, uri, id, label)
+      expect(result).to.equal(uri)
+    })
+})


### PR DESCRIPTION
Uri generator was moved to separate file to make it easier to test. Empty mrefs selections resulted
in search for empty value, which resulted in error. Search for empty list now results in uri without
query.

Fixes #291

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Clean commits
- [x] No warnings during install
- [x] Updated flow typing
