### PR TITLE
task: remove safari e2e test from master  build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,8 @@ pipeline {
           sh "yarn install"
           sh "yarn lint"
           sh "yarn unit"
-          sh "yarn e2e --env ci_chrome,ci_safari,ci_ie11,ci_firefox"
+          // sh "yarn e2e --env ci_chrome,ci_safari,ci_ie11,ci_firefox" skip safari untill K8s JENKINS_AGENT_NAME issue can be fixed
+          sh "yarn e2e --env ci_chrome,ci_ie11,ci_firefox"
         }
       }
       post {


### PR DESCRIPTION
BREAKING CHANGE: release previously unreleased change due to build issue

- Replace i18n key 'ui-form:form_not_a_valid_url' with 'ui-form:form_not_a_valid_hyperlink'

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Updated flow typing
