### PR TITLE
Fix/333 missing add in compound

### DIFF
--- a/src/components/FormFieldComponent.vue
+++ b/src/components/FormFieldComponent.vue
@@ -51,6 +51,7 @@
           :level="level + 1"
           :showOptionalFields="showOptionalFields"
           :key="child.id"
+          :formComponentOptions="formComponentOptions"
           @dataChange="onDataChange">
         </form-field-component>
       </div>

--- a/src/example/compound/CompoundExample.vue
+++ b/src/example/compound/CompoundExample.vue
@@ -12,6 +12,7 @@
               :initialFormData="formData"
               :formState="formState"
               @valueChange="onValueChanged"
+              @addOptionRequest="onAddOptionRequest"
             ></form-component>
           </div>
         </div>
@@ -86,6 +87,9 @@ export default {
   methods: {
     onValueChanged (formData) {
       this.formData = formData
+    },
+    onAddOptionRequest (optionCreatedCallback, event, sourceField) {
+      alert('onAddOptionRequest from: ' + sourceField.id)
     }
   },
   filters: {

--- a/test/e2e/specs/compound-test.js
+++ b/test/e2e/specs/compound-test.js
@@ -14,5 +14,11 @@ module.exports = {
     browser.expect.element('fieldset fieldset#compound-string-fs').to.be.present
     browser.expect.element('fieldset fieldset#compound-multi-select-fs').to.be.present
     browser.end()
+  },
+
+  'Should show add option button for mref': function (browser) {
+    browser.options.desiredCapabilities.name = 'Show add option button for mref'
+    browser.expect.element('fieldset fieldset#compound-multi-select-fs .mg-select-add-btn').to.be.present
+    browser.end()
   }
 }

--- a/test/e2e/specs/compound-test.js
+++ b/test/e2e/specs/compound-test.js
@@ -1,0 +1,18 @@
+/* eslint-disable no-unused-expressions */
+
+module.exports = {
+  tags: ['compound'], // run this suite with 'yarn e2e --tag compound'
+  beforeEach: function (browser) {
+    // Wait for form to be loaded
+    browser.url(browser.globals.devServerURL)
+    browser.url(browser.globals.devServerURL + '/compound')
+  },
+
+  'Should show fields inside compound': function (browser) {
+    browser.options.desiredCapabilities.name = 'Show fields inside compound'
+    browser.expect.element('#compound-example-fs').to.be.present
+    browser.expect.element('fieldset fieldset#compound-string-fs').to.be.present
+    browser.expect.element('fieldset fieldset#compound-multi-select-fs').to.be.present
+    browser.end()
+  }
+}


### PR DESCRIPTION
- Pass on formComponentOptions recursively
- Add e2e test case to check button is now added to mref field when inside compound and showAddButton option is set

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Updated flow typing
