### PR TITLE
fix: disable CI e2e tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,17 +12,17 @@ pipeline {
         }
         container('vault') {
           script {
-            env.TUNNEL_IDENTIFIER = sh(script: 'echo ${GIT_COMMIT}-${BUILD_NUMBER}', returnStdout: true)
+            // env.TUNNEL_IDENTIFIER = sh(script: 'echo ${GIT_COMMIT}-${BUILD_NUMBER}', returnStdout: true)
             env.GITHUB_TOKEN = sh(script: 'vault read -field=value secret/ops/token/github', returnStdout: true)
             env.CODECOV_TOKEN = sh(script: 'vault read -field=molgenis-ui-form secret/ops/token/codecov', returnStdout: true)
-            env.SAUCE_CRED_USR = sh(script: 'vault read -field=username secret/ops/token/saucelabs', returnStdout: true)
-            env.SAUCE_CRED_PSW = sh(script: 'vault read -field=value secret/ops/token/saucelabs', returnStdout: true)
+            // env.SAUCE_CRED_USR = sh(script: 'vault read -field=username secret/ops/token/saucelabs', returnStdout: true)
+            // env.SAUCE_CRED_PSW = sh(script: 'vault read -field=value secret/ops/token/saucelabs', returnStdout: true)
             env.NPM_TOKEN = sh(script: 'vault read -field=value secret/ops/token/npm', returnStdout: true)
           }
         }
-        container('node') {
-          sh "daemon --name=sauceconnect -- /usr/local/bin/sc -u ${SAUCE_CRED_USR} -k ${SAUCE_CRED_PSW} -i ${TUNNEL_IDENTIFIER}"
-        }
+        // container('node') {
+          // sh "daemon --name=sauceconnect -- /usr/local/bin/sc -u ${SAUCE_CRED_USR} -k ${SAUCE_CRED_PSW} -i ${TUNNEL_IDENTIFIER}"
+        // }
       }
     }
     stage('Build: [ pull request ]') {
@@ -35,7 +35,7 @@ pipeline {
           sh "yarn lint"
           sh "yarn unit"
           // sh "yarn e2e --env ci_chrome,ci_safari,ci_ie11,ci_firefox" skip safari untill K8s JENKINS_AGENT_NAME issue can be fixed
-          sh "yarn e2e --env ci_chrome,ci_ie11,ci_firefox"
+          // sh "yarn e2e --env ci_chrome,ci_ie11,ci_firefox"
         }
       }
       post {
@@ -62,7 +62,7 @@ pipeline {
           sh "yarn lint"
           sh "yarn unit"
           // sh "yarn e2e --env ci_chrome,ci_safari,ci_ie11,ci_firefox" skip safari untill K8s JENKINS_AGENT_NAME issue can be fixed
-          sh "yarn e2e --env ci_chrome,ci_ie11,ci_firefox"
+          // sh "yarn e2e --env ci_chrome,ci_ie11,ci_firefox"
         }
       }
       post {
@@ -98,11 +98,11 @@ pipeline {
     }
   }
   post {
-    always {
-      container('node') {
-        sh "daemon --name=sauceconnect --stop"
-      }
-    }
+    // always {
+      // container('node') {
+        // sh "daemon --name=sauceconnect --stop"
+      // }
+    // }
     failure {
       hubotSend(message: 'Build failed', status:'ERROR', site: 'slack-pr-app-team')
     }


### PR DESCRIPTION
Disable CI e2e tests until we fix the jenkins plugin

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Clean commits
- [ ] No warnings during install
- [ ] Updated flow typing
